### PR TITLE
Minor updates to travis and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 open-estimate
 =============
 
-
+.. image:: https://travis-ci.org/ClimateImpactLab/open-estimate.svg?branch=master
+    :target: https://travis-ci.org/ClimateImpactLab/open-estimate
 
 Crowd-Sourcing Model Aggregation Library
 

--- a/README.rst
+++ b/README.rst
@@ -9,19 +9,14 @@ Crowd-Sourcing Model Aggregation Library
 Installation
 ------------
 
-This library depends on numpy and scipy.  In addition, to use Mean-Size hierarchical sampling, the emcee library must be installed.
+This library depends on numpy and scipy.  In addition, to use Mean-Size hierarchical sampling, the emcee library must be installed
 
-```
-pip install numpy
-pip install scipy
-pip install emcee
-```
+If the source is available in the current working directory, install this package with::
 
-Install the package by calling
-```
-python setup.py install
-```
-(or use `develop` rather than install if you'll be editing the code).
+    pip install .
 
+or ``pip install . -e`` if you would like to edit the code locally.
+
+You can install this package directly from its github repo with ``pip install git+https://github.com/ClimateImpactLab/open-estimate.git``
 
 Full Documentation can be found `here <http://openest.readthedocs.io/en/master/>`_.

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -12,5 +12,6 @@ dependencies:
   - pytest
   - pytest-mock
   - coverage
+  - pip
   - pip:
       - metacsv


### PR DESCRIPTION
Very minor updates to travis file and README.

- README now has travis badge
- README gives remote and local install instructions using `pip`
- travis no longer bugs me about not spec-ing a pip version in the CI environment file