### PR TITLE
Constrain/clip projected values

### DIFF
--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -685,5 +685,5 @@ class Clip(calculation.Calculation):
 
         """
         return dict(input_timerate='any', output_timerate='same',
-                    arguments=[arguments.calculation, arguments.numeric, arguments.numeric],
+                    arguments=[arguments.calculation, arguments.numeric.rename('min'), arguments.numeric.rename('max')],
                     description="Return the clipped values of a previous result.")

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -1,11 +1,33 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
+import pytest
 
 from openest.generate.base import Constant
 from openest.generate.daily import YearlyDayBins
-from openest.generate.functions import Scale, Instabase, SpanInstabase
+from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip
 from .test_daily import test_curve
+
+
+class MockApplication:
+    """Mocks openest.generate.calculation.Application for ease
+
+    This primarily allows us to prime the Application generators with simple Sequences.
+    """
+    def __init__(self, years, values, unitses):
+        self.unitses = unitses
+        # Mimic generator nature of the data, test if data leaks.
+        self.data = zip(years, values)
+
+    def apply(self, *args, **kwargs):
+        return self
+
+    def column_info(self):
+        return [{'name': 'mockname', 'title': 'mocktitle', 'description': 'mockdescription'}]
+
+    def push(self, *args, **kwargs):
+        for x in self.data:
+            yield x
 
 
 def make_year_ds(year, values):
@@ -13,6 +35,7 @@ def make_year_ds(year, values):
     time_coord = pd.date_range(year + '-01-01', periods=365)
     return xr.Dataset({'x': (['time'], values)},
                       coords={'time': time_coord})
+
 
 def test_scale():
     application = Scale(Constant(33, 'widgets'), {'test': 1. / 11}, 'widgets', 'subwigs').test()
@@ -67,3 +90,54 @@ def test_spaninstabase():
             np.testing.assert_equal(yearresult[1], 1.)
         if yearresult[0] == 2:
             np.testing.assert_equal(yearresult[1], 1.)
+
+
+class TestClip:
+    """Basic tests for openest.generate.functions.Clip
+    """
+    def test_units_append(self):
+        """Tests that Clip instances correctly append units from the original subcalc
+        """
+        unit = ['fakeunit']
+        subcalc_mock = MockApplication(years=[0], values=[1.0], unitses=unit)
+        clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
+        assert clipped_calc.unitses == unit * 2
+
+    @pytest.mark.parametrize(
+        "in_years,in_values,expected",
+        [
+            ([0], [-0.5], [0, 0.0, -0.5]),
+            ([1], [0.0], [1, 0.0, 0.0]),
+            ([2], [0.5], [2, 0.5, 0.5]),
+        ],
+        ids=['outside clip', 'clip edge', 'inside clip'],
+    )
+    def test_apply(self, in_years, in_values, expected):
+        """Test self.apply() clips values in, out, and on edge of interval
+        """
+        subcalc_mock = MockApplication(
+            years=in_years,
+            values=in_values,
+            unitses=['fakeunit'],
+        )
+        clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
+        victim_gen = clipped_calc.apply('foobar_region').push('not_a_ds')
+        assert next(victim_gen) == expected
+
+    def test_column_info(self):
+        """Ensure self.column_info() appends dict with correct keys
+        """
+        subcalc_mock = MockApplication(years=[0], values=[1.0], unitses=['fakeunit'])
+        clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
+        victim = clipped_calc.column_info()
+        # Check that first dict is from Clip instance
+        assert victim[0]['name'] == 'clip'
+        assert list(victim[0].keys()) == ['name', 'title', 'description']
+
+    def test_describe(self):
+        """Ensure self.describe() returns dict with correct keys
+        """
+        subcalc_mock = MockApplication(years=[0], values=[1.0], unitses=['fakeunit'])
+        clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
+        victim = clipped_calc.describe()
+        assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -124,6 +124,21 @@ class TestClip:
         victim_gen = clipped_calc.apply('foobar_region').push('not_a_ds')
         assert next(victim_gen) == expected
 
+    def test_apply_memory(self):
+        """Test that Clip.apply() doesn't hold memory between yields
+        """
+        subcalc_mock = MockApplication(
+            years=[0, 1, 2],
+            values=[0.0, 0.5, 1.0],
+            unitses=['fakeunit'],
+        )
+        clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
+        victim_gen = clipped_calc.apply('foobar_region').push('not_a_ds')
+        iter0 = next(victim_gen)
+        iter1 = next(victim_gen)
+        iter2 = next(victim_gen)
+        assert (iter0 == [0, 0.0, 0.0]) and (iter1 == [1, 0.5, 0.5]) and (iter2 == [2, 1.0, 1.0])
+
     def test_column_info(self):
         """Ensure self.column_info() appends dict with correct keys
         """

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -113,7 +113,7 @@ class TestClip:
         ids=['outside clip', 'clip edge', 'inside clip'],
     )
     def test_apply(self, in_years, in_values, expected):
-        """Test self.apply() clips values in, out, and on edge of interval
+        """Test Clip.apply() clips values in, out, and on edge of interval
         """
         subcalc_mock = MockApplication(
             years=in_years,
@@ -140,7 +140,7 @@ class TestClip:
         assert (iter0 == [0, 0.0, 0.0]) and (iter1 == [1, 0.5, 0.5]) and (iter2 == [2, 1.0, 1.0])
 
     def test_column_info(self):
-        """Ensure self.column_info() appends dict with correct keys
+        """Ensure Clip.column_info() appends dict with correct keys
         """
         subcalc_mock = MockApplication(years=[0], values=[1.0], unitses=['fakeunit'])
         clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
@@ -150,7 +150,7 @@ class TestClip:
         assert list(victim[0].keys()) == ['name', 'title', 'description']
 
     def test_describe(self):
-        """Ensure self.describe() returns dict with correct keys
+        """Ensure Clip.describe() returns dict with correct keys
         """
         subcalc_mock = MockApplication(years=[0], values=[1.0], unitses=['fakeunit'])
         clipped_calc = Clip(subcalc_mock, 0.0, 1.0)


### PR DESCRIPTION
Closes #27. This feature is needed for downstream development of labor sector projections.

The PR adds a new `Clip` Calculation subclass to `openest/generate/functions.py`. To instantiate, this new class needs a subcalculation as well as min, max values - defining the interval to clip subcalculation values to.

This PR includes unit tests for the new subclass.