### PR TITLE
Add Product calculation

### DIFF
--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -497,10 +497,7 @@ class Product(calculation.Calculation):
         """
 
         def generate(year, results):
-            if not self.deltamethod:
-                return np.prod([x[1] if x is not None else np.nan for x in results])
-            else:
-                return np.prod([x[1] if x is not None else np.nan for x in results], 0)
+            return np.prod([x[1] if x is not None else np.nan for x in results])
 
         # Prepare the generator from our encapsulated operations
         subapps = [subcalc.apply(region, *args, **kwargs) for subcalc in self.subcalcs]

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -455,8 +455,6 @@ class Prod(calculation.Calculation):
     def __init__(self, subcalcs, unshift=True):
         fullunitses = subcalcs[0].unitses[:]
         for ii in range(1, len(subcalcs)):
-            assert subcalcs[0].unitses[0] == subcalcs[ii].unitses[0], "%s <> %s" % (
-            subcalcs[0].unitses[0], subcalcs[ii].unitses[0])
             fullunitses.extend(subcalcs[ii].unitses)
         if unshift:
             super().__init__([subcalcs[0].unitses[0]] + fullunitses)

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -443,7 +443,7 @@ class Sum(calculation.Calculation):
                     description="Sum the results of multiple previous calculations.")
 
 
-class Prod(calculation.Calculation):
+class Product(calculation.Calculation):
     """Product of two or more subcalculations
 
     Parameters
@@ -476,7 +476,7 @@ class Prod(calculation.Calculation):
         if lang in ['latex', 'julia']:
             elements['main'] = FormatElement(' * '.join([main.repstr for main in mains]), list(alldeps))
 
-        formatting.add_label('prod', elements)
+        formatting.add_label('product', elements)
         return elements
 
     def apply(self, region, *args, **kwargs):
@@ -529,7 +529,7 @@ class Prod(calculation.Calculation):
         fullinfos = []
         for infos in infoses:
             fullinfos.extend(infos)
-        return [dict(name='prod', title=title, description=description)] + fullinfos
+        return [dict(name='product', title=title, description=description)] + fullinfos
 
     def enable_deltamethod(self):
         raise NotImplementedError

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -543,7 +543,20 @@ class Product(calculation.Calculation):
         derivative with respect to a given variable; currently only covariates
         are supported.
         """
-        return Sum([subcalc.partial_derivative(covariate, covarunit) for subcalc in self.subcalcs])
+        # Partial deriv should be sum of products
+        chain_products = []
+        for i in range(len(self.subcalcs)):
+
+            # product of (∂subcalc[i] / ∂covariate) and all other subcalcs
+            chain_products.append(
+                Product(
+                    [self.subcalcs[i].partial_derivative(covariate, covarunit)]
+                    + self.subcalcs[:i]
+                    + self.subcalcs[(i + 1):]
+                )
+            )
+
+        return Sum(chain_products)
 
     @staticmethod
     def describe():

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -456,10 +456,13 @@ class Product(calculation.Calculation):
         fullunitses = subcalcs[0].unitses[:]
         for ii in range(1, len(subcalcs)):
             fullunitses.extend(subcalcs[ii].unitses)
+
+        # Unit of result is product of input subcalc units.
+        units_product = [" * ".join([s.unitses[0] for s in subcalcs])]
         if unshift:
-            super().__init__([subcalcs[0].unitses[0]] + fullunitses)
+            super().__init__(units_product + fullunitses)
         else:
-            super().__init__([subcalcs[0].unitses[0]])
+            super().__init__(units_product)
 
         self.unshift = unshift
         self.subcalcs = subcalcs

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -446,6 +446,8 @@ class Sum(calculation.Calculation):
 class Product(calculation.Calculation):
     """Product of two or more subcalculations
 
+    Note that this does not support delta-method runs.
+
     Parameters
     ----------
     subcalcs : Sequence of ``openest.generate.calculation.Calculation``
@@ -527,7 +529,11 @@ class Product(calculation.Calculation):
         return [dict(name='product', title=title, description=description)] + fullinfos
 
     def enable_deltamethod(self):
-        raise NotImplementedError
+        """Enable delta-method calculations
+
+        Delta-method is unsupported for this calculation.
+        """
+        raise AttributeError(f'{self.__class__} does not support enabling deltamethod')
 
     def partial_derivative(self, covariate, covarunit):
         """

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -532,9 +532,7 @@ class Prod(calculation.Calculation):
         return [dict(name='prod', title=title, description=description)] + fullinfos
 
     def enable_deltamethod(self):
-        self.deltamethod = True
-        for subcalc in self.subcalcs:
-            subcalc.enable_deltamethod()
+        raise NotImplementedError
 
     def partial_derivative(self, covariate, covarunit):
         """

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -5,7 +5,7 @@ import pytest
 
 from openest.generate.base import Constant
 from openest.generate.daily import YearlyDayBins
-from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum
+from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum, Prod
 from .test_daily import test_curve
 
 
@@ -155,6 +155,72 @@ class TestSum:
         subcalc_mock1 = MockAppCalc(years=[0], values=[1.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         sum_calc = Sum([subcalc_mock1, subcalc_mock2])
+        victim = sum_calc.describe()
+        assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
+
+
+class TestProd:
+    """
+    Basic tests for openest.generate.functions.Prod
+    """
+    @pytest.mark.parametrize(
+        "unshift_flag,n_expected",
+        [(True, 3), (False, 1)],
+        ids=['shifted', 'unshifted'],
+    )
+    def test_units_append(self, unshift_flag, n_expected):
+        """Tests that Prod instances correctly append units from the original subcalcs
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+
+        sum_calc = Prod([subcalc_mock1, subcalc_mock2], unshift=unshift_flag)
+        assert sum_calc.unitses == unit * n_expected
+
+    def test_apply(self):
+        """Test Prod.apply() actually multiplies values
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+
+        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
+        assert next(victim_gen) == [0, 6.0, 2.0, 3.0]
+
+    def test_apply_memory(self):
+        """Test that Prod.apply() doesn't hold memory between yields
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0, 1], values=[2.0, 3.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0, 1], values=[3.0, 4.0], unitses=unit)
+        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+
+        victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
+        iter0 = next(victim_gen)
+        iter1 = next(victim_gen)
+        assert (iter0 == [0, 6.0, 2.0, 3.0]) and (iter1 == [1, 12.0, 3.0, 4.0])
+
+    def test_column_info(self):
+        """Ensure Prod.column_info() appends dict with correct keys
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        victim = sum_calc.column_info()
+        # Check that first dict is from Sum instance
+        assert victim[0]['name'] == 'prod'
+        assert list(victim[0].keys()) == ['name', 'title', 'description']
+
+    def test_describe(self):
+        """Ensure Prod.describe() returns dict with correct keys
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
         victim = sum_calc.describe()
         assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
 

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -5,7 +5,7 @@ import pytest
 
 from openest.generate.base import Constant
 from openest.generate.daily import YearlyDayBins
-from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum, Prod
+from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum, Product
 from .test_daily import test_curve
 
 
@@ -159,9 +159,9 @@ class TestSum:
         assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
 
 
-class TestProd:
+class TestProduct:
     """
-    Basic tests for openest.generate.functions.Prod
+    Basic tests for openest.generate.functions.Product
     """
     @pytest.mark.parametrize(
         "unshift_flag,n_expected",
@@ -169,33 +169,33 @@ class TestProd:
         ids=['shifted', 'unshifted'],
     )
     def test_units_append(self, unshift_flag, n_expected):
-        """Tests that Prod instances correctly append units from the original subcalcs
+        """Tests that Product instances correctly append units from the original subcalcs
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
 
-        sum_calc = Prod([subcalc_mock1, subcalc_mock2], unshift=unshift_flag)
+        sum_calc = Product([subcalc_mock1, subcalc_mock2], unshift=unshift_flag)
         assert sum_calc.unitses == unit * n_expected
 
     def test_apply(self):
-        """Test Prod.apply() actually multiplies values
+        """Test Product.apply() actually multiplies values
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
 
-        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        sum_calc = Product([subcalc_mock1, subcalc_mock2])
         victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
         assert next(victim_gen) == [0, 6.0, 2.0, 3.0]
 
     def test_apply_memory(self):
-        """Test that Prod.apply() doesn't hold memory between yields
+        """Test that Product.apply() doesn't hold memory between yields
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0, 1], values=[2.0, 3.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0, 1], values=[3.0, 4.0], unitses=unit)
-        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        sum_calc = Product([subcalc_mock1, subcalc_mock2])
 
         victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
         iter0 = next(victim_gen)
@@ -203,24 +203,24 @@ class TestProd:
         assert (iter0 == [0, 6.0, 2.0, 3.0]) and (iter1 == [1, 12.0, 3.0, 4.0])
 
     def test_column_info(self):
-        """Ensure Prod.column_info() appends dict with correct keys
+        """Ensure Product.column_info() appends dict with correct keys
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
-        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        sum_calc = Product([subcalc_mock1, subcalc_mock2])
         victim = sum_calc.column_info()
         # Check that first dict is from Sum instance
-        assert victim[0]['name'] == 'prod'
+        assert victim[0]['name'] == 'product'
         assert list(victim[0].keys()) == ['name', 'title', 'description']
 
     def test_describe(self):
-        """Ensure Prod.describe() returns dict with correct keys
+        """Ensure Product.describe() returns dict with correct keys
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
-        sum_calc = Prod([subcalc_mock1, subcalc_mock2])
+        sum_calc = Product([subcalc_mock1, subcalc_mock2])
         victim = sum_calc.describe()
         assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
 

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -164,19 +164,24 @@ class TestProduct:
     Basic tests for openest.generate.functions.Product
     """
     @pytest.mark.parametrize(
-        "unshift_flag,n_expected",
-        [(True, 3), (False, 1)],
+        "unshift_flag",
+        [(True), (False)],
         ids=['shifted', 'unshifted'],
     )
-    def test_units_append(self, unshift_flag, n_expected):
-        """Tests that Product instances correctly append units from the original subcalcs
+    def test_units_append(self, unshift_flag):
+        """Tests that Product correctly tacks on units from the original subcalcs
         """
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+        in_calcs = [subcalc_mock1, subcalc_mock2]
 
-        sum_calc = Product([subcalc_mock1, subcalc_mock2], unshift=unshift_flag)
-        assert sum_calc.unitses == unit * n_expected
+        sub_calc = Product(in_calcs, unshift=unshift_flag)
+
+        expected = [" * ".join(unit * len(in_calcs))]
+        if unshift_flag:
+            expected += unit * len(in_calcs)
+        assert sub_calc.unitses == expected
 
     def test_apply(self):
         """Test Product.apply() actually multiplies values

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -176,12 +176,12 @@ class TestProduct:
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
         in_calcs = [subcalc_mock1, subcalc_mock2]
 
-        sub_calc = Product(in_calcs, unshift=unshift_flag)
+        prod_calc = Product(in_calcs, unshift=unshift_flag)
 
         expected = [" * ".join(unit * len(in_calcs))]
         if unshift_flag:
             expected += unit * len(in_calcs)
-        assert sub_calc.unitses == expected
+        assert prod_calc.unitses == expected
 
     def test_apply(self):
         """Test Product.apply() actually multiplies values
@@ -190,8 +190,8 @@ class TestProduct:
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
 
-        sum_calc = Product([subcalc_mock1, subcalc_mock2])
-        victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
+        prod_calc = Product([subcalc_mock1, subcalc_mock2])
+        victim_gen = prod_calc.apply('foobar_region').push('not_a_ds')
         assert next(victim_gen) == [0, 6.0, 2.0, 3.0]
 
     def test_apply_memory(self):
@@ -200,9 +200,9 @@ class TestProduct:
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0, 1], values=[2.0, 3.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0, 1], values=[3.0, 4.0], unitses=unit)
-        sum_calc = Product([subcalc_mock1, subcalc_mock2])
+        prod_calc = Product([subcalc_mock1, subcalc_mock2])
 
-        victim_gen = sum_calc.apply('foobar_region').push('not_a_ds')
+        victim_gen = prod_calc.apply('foobar_region').push('not_a_ds')
         iter0 = next(victim_gen)
         iter1 = next(victim_gen)
         assert (iter0 == [0, 6.0, 2.0, 3.0]) and (iter1 == [1, 12.0, 3.0, 4.0])
@@ -213,8 +213,8 @@ class TestProduct:
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
-        sum_calc = Product([subcalc_mock1, subcalc_mock2])
-        victim = sum_calc.column_info()
+        prod_calc = Product([subcalc_mock1, subcalc_mock2])
+        victim = prod_calc.column_info()
         # Check that first dict is from Sum instance
         assert victim[0]['name'] == 'product'
         assert list(victim[0].keys()) == ['name', 'title', 'description']
@@ -225,9 +225,20 @@ class TestProduct:
         unit = ['fakeunit']
         subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
         subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
-        sum_calc = Product([subcalc_mock1, subcalc_mock2])
-        victim = sum_calc.describe()
+        prod_calc = Product([subcalc_mock1, subcalc_mock2])
+        victim = prod_calc.describe()
         assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
+
+    def test_enable_deltamethod_exception(self):
+        """Ensure that Product.enable_deltamethod() raises an exception
+        """
+        unit = ['fakeunit']
+        subcalc_mock1 = MockAppCalc(years=[0], values=[2.0], unitses=unit)
+        subcalc_mock2 = MockAppCalc(years=[0], values=[3.0], unitses=unit)
+        prod_calc = Product([subcalc_mock1, subcalc_mock2])
+
+        with pytest.raises(AttributeError):
+            prod_calc.enable_deltamethod()
 
 
 class TestClip:


### PR DESCRIPTION
Adds `Product` Calculation.

It acts like the existing `Sum` but instead gives the product of subcalculations.

This PR includes docstrings and unit tests for the new feature.