### PR TITLE
Support keeping tas order after u-shaping

### DIFF
--- a/models/curve.py
+++ b/models/curve.py
@@ -1,5 +1,5 @@
 import numpy as np
-from univariate_model import UnivariateModel
+from openest.models.univariate_model import UnivariateModel
 from scipy.interpolate import UnivariateSpline
 from statsmodels.distributions.empirical_distribution import StepFunction
 

--- a/models/univariate_model.py
+++ b/models/univariate_model.py
@@ -1,4 +1,4 @@
-from model import Model
+from openest.models.model import Model
 import numpy as np
 
 class UnivariateModel(Model):

--- a/openest/curves/ushape_analytic.py
+++ b/openest/curves/ushape_analytic.py
@@ -101,7 +101,7 @@ def mergeplateaus(alllimits, spans, levels, evalpts):
 def derivative_clipping(ccs, mintemp):
     # Ordered as x, x^2, x^3, x^4
     derivcoeffs = polyderiv(ccs)
-    roots = filter(np.isreal, np.roots(derivcoeffs[::-1])) # only consider real roots
+    roots = list(filter(np.isreal, np.roots(derivcoeffs[::-1]))) # only consider real roots
     
     deriv2coeffs = derivcoeffs[1:] * np.arange(1, len(derivcoeffs)) # Second derivative
     direction = np.polyval(deriv2coeffs[::-1], roots)

--- a/openest/curves/ushape_numeric.py
+++ b/openest/curves/ushape_numeric.py
@@ -2,8 +2,24 @@ import numpy as np
 from openest.curves.basic import UnivariateCurve
 
 class UShapedCurve(UnivariateCurve):
-    def __init__(self, curve, mintemp, gettas, ordered=False, fillxxs=[], fillyys=[]):
-        # Ordered only used for unit testing
+    """A curve that returns values that clips another curve to maintain a u-shape.
+
+    Parameters
+    ----------
+    curve : UnivariateCurve
+        The curve to be clipped.
+    mintemp : float
+        The temperature forced to be at the lowest point in the curve.
+    gettas : function(xs) -> array_like
+        Returns the core temperature variable from whatever the curve is called with.
+    ordered : boolean or 'maintain'
+        If 'maintain', return order according to tas; if True, increasing tas order
+    fillxxs : array_like
+        Temperature values for a grid of additional sampled temperatures
+    fillyys : array_like
+        The dependent variables that correspond to fillxxs
+    """
+    def __init__(self, curve, mintemp, gettas, ordered='maintain', fillxxs=[], fillyys=[]):
         super(UShapedCurve, self).__init__(curve.xx)
         self.curve = curve
         self.mintemp = mintemp
@@ -16,19 +32,16 @@ class UShapedCurve(UnivariateCurve):
         values = self.curve(xs)
         tas = self.gettas(xs)
 
+        # Add in the grid for completeness
         if len(self.fillxxs) > 0:
             tas_saved = tas
             tas = np.concatenate((tas, self.fillxxs))
             values = np.concatenate((values, self.fillyys))
 
+        # Order into increasing values left and right of mintemp
         order = np.argsort(tas)
         orderedtas = tas[order]
         orderedvalues = values[order]
-
-        if len(self.fillxxs) > 0:
-            tokeeps = order < len(tas_saved)
-            lowkeeps = tokeeps[orderedtas < self.mintemp]
-            highkeeps = tokeeps[orderedtas >= self.mintemp]
 
         lowvalues = orderedvalues[orderedtas < self.mintemp]
         lowvalues2 = np.maximum.accumulate(lowvalues[::-1])
@@ -36,19 +49,47 @@ class UShapedCurve(UnivariateCurve):
         highvalues = orderedvalues[orderedtas >= self.mintemp]
         highvalues2 = np.maximum.accumulate(highvalues)
 
-        if len(self.fillxxs) > 0:
-            # Remove the fillins
-            lowvalues2 = lowvalues2[lowkeeps[::-1]]
-            highvalues2 = highvalues2[highkeeps]
-        
-        if self.ordered:
-            return np.concatenate((lowvalues2[::-1], highvalues2))
+        if self.ordered == 'maintain':
+            # Put it all back together
+            increasing = np.concatenate((lowvalues2[::-1], highvalues2))
+            # Undo the ordering
+            tasorder = np.empty(len(increasing))
+            tasorder[order] = increasing
+            # Return just the given values
+            return tasorder[:len(xs)]
         else:
-            return np.concatenate((lowvalues2, highvalues2))
+            if len(self.fillxxs) > 0:
+                tokeeps = order < len(tas_saved)
+                lowkeeps = tokeeps[orderedtas < self.mintemp]
+                highkeeps = tokeeps[orderedtas >= self.mintemp]
+
+                # Remove the fillins
+                lowvalues2 = lowvalues2[lowkeeps[::-1]]
+                highvalues2 = highvalues2[highkeeps]
+
+            if self.ordered:
+                return np.concatenate((lowvalues2[::-1], highvalues2))
+            else:
+                return np.concatenate((lowvalues2, highvalues2))
 
 # Return tmarginal evaluated at the innermost edge of plateaus
 class UShapedClipping(UnivariateCurve):
-    def __init__(self, curve, tmarginal_curve, mintemp, gettas, ordered=False):
+    """Clip marginal effects to zero where a curve is u-clipped
+
+    Parameters
+    ----------
+    curve : UnivariateCurve
+        Curve that has been u-clipped (but may not be a UShapedCurve).
+    tmarginal_curve : UnivariateCurve
+        Curve representing the marginal effects wrt temperature.
+    mintemp : float
+        The temperature forced to be at the lowest point in the curve.
+    gettas : function(xs) -> array_like
+        Returns the core temperature variable from whatever the curve is called with.
+    ordered : boolean or 'maintain'
+        Must use the same value as the corresponding UShapedCurve
+    """
+    def __init__(self, curve, tmarginal_curve, mintemp, gettas, ordered='maintain'):
         super(UShapedClipping, self).__init__(curve.xx)
         self.curve = curve
         self.tmarginal_curve = tmarginal_curve
@@ -57,32 +98,73 @@ class UShapedClipping(UnivariateCurve):
         self.ordered = ordered
 
     def __call__(self, xs):
-        increasingvalues = self.curve(xs) # these are ordered as low..., high...
-        increasingplateaus = np.diff(increasingvalues) == 0
+        if self.ordered == 'maintain':
+            tas = self.gettas(xs)
+            order = np.argsort(tas)
+            orderedtas = tas[order]
 
-        tas = self.gettas(xs)
-        order = np.argsort(tas)
-        orderedtas = tas[order]
+            # Order the clipped values to low..., high...
+            clippedvalues = self.curve(xs)
+            orderedvalues = clippedvalues[order]
 
-        n_below = sum(orderedtas < self.mintemp)
-        
-        lowindicesofordered = np.arange(n_below)[::-1] # [N-1 ... 0]
-        if len(lowindicesofordered) > 1:
-            lowindicesofordered[np.concatenate(([False], increasingplateaus[:len(lowindicesofordered)-1]))] = n_below
-            lowindicesofordered = np.minimum.accumulate(lowindicesofordered)
-        
-        highindicesofordered = np.arange(sum(orderedtas >= self.mintemp)) + n_below # [N ... T-1]
-        if len(highindicesofordered) > 1:
-            highindicesofordered[np.concatenate(([False], increasingplateaus[-len(highindicesofordered)+1:]))] = n_below
-            highindicesofordered = np.maximum.accumulate(highindicesofordered)
+            n_below = sum(orderedtas < self.mintemp)
 
-        if len(xs.shape) == 2:
-            increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered], :]), self.tmarginal_curve(xs[order[highindicesofordered], :]))) # ordered low..., high...
+            increasingvalues = np.concatenate((orderedvalues[:n_below][::-1], orderedvalues[n_below:]))
+
+            # Find the plateaus
+            increasingplateaus = np.diff(increasingvalues) == 0
+
+            # Apply tmarginal at index just-before clipping (boat raises all)
+            lowindicesofordered = np.arange(n_below)[::-1] # [N-1 ... 0]
+            if len(lowindicesofordered) > 1:
+                lowindicesofordered[np.concatenate(([False], increasingplateaus[:len(lowindicesofordered)-1]))] = n_below
+                lowindicesofordered = np.minimum.accumulate(lowindicesofordered)
+            
+            highindicesofordered = np.arange(sum(orderedtas >= self.mintemp)) + n_below # [N ... T-1]
+            if len(highindicesofordered) > 1:
+                highindicesofordered[np.concatenate(([False], increasingplateaus[-len(highindicesofordered)+1:]))] = n_below
+                highindicesofordered = np.maximum.accumulate(highindicesofordered)
+
+            # Construct the results
+            if len(xs.shape) == 2:
+                increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered], :]), self.tmarginal_curve(xs[order[highindicesofordered], :]))) # ordered low..., high...
+            else:
+                increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered]]), self.tmarginal_curve(xs[order[highindicesofordered]]))) # ordered low..., high...
+            increasingresults[increasingvalues <= 0] = 0 # replace truly clipped with 0
+
+            orderedresults = np.concatenate((increasingresults[:n_below][::-1], increasingresults[n_below:]))
+            
+            # Undo the ordering
+            tasorder = np.empty(len(orderedresults))
+            tasorder[order] = orderedresults
+            return tasorder
         else:
-            increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered]]), self.tmarginal_curve(xs[order[highindicesofordered]]))) # ordered low..., high...
-        increasingresults[increasingvalues <= 0] = 0 # replace truly clipped with 0
+            increasingvalues = self.curve(xs) # these are ordered as low..., high...
+            increasingplateaus = np.diff(increasingvalues) == 0
 
-        if self.ordered:
-            return np.concatenate((increasingresults[tas < self.mintemp][::-1], increasingresults[tas >= self.mintemp]))
-        else:
-            return increasingresults
+            tas = self.gettas(xs)
+            order = np.argsort(tas)
+            orderedtas = tas[order]
+            
+            n_below = sum(orderedtas < self.mintemp)
+        
+            lowindicesofordered = np.arange(n_below)[::-1] # [N-1 ... 0]
+            if len(lowindicesofordered) > 1:
+                lowindicesofordered[np.concatenate(([False], increasingplateaus[:len(lowindicesofordered)-1]))] = n_below
+                lowindicesofordered = np.minimum.accumulate(lowindicesofordered)
+            
+            highindicesofordered = np.arange(sum(orderedtas >= self.mintemp)) + n_below # [N ... T-1]
+            if len(highindicesofordered) > 1:
+                highindicesofordered[np.concatenate(([False], increasingplateaus[-len(highindicesofordered)+1:]))] = n_below
+                highindicesofordered = np.maximum.accumulate(highindicesofordered)
+
+            if len(xs.shape) == 2:
+                increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered], :]), self.tmarginal_curve(xs[order[highindicesofordered], :]))) # ordered low..., high...
+            else:
+                increasingresults = np.concatenate((self.tmarginal_curve(xs[order[lowindicesofordered]]), self.tmarginal_curve(xs[order[highindicesofordered]]))) # ordered low..., high...
+            increasingresults[increasingvalues <= 0] = 0 # replace truly clipped with 0
+
+            if self.ordered:
+                return np.concatenate((increasingresults[tas < self.mintemp][::-1], increasingresults[tas >= self.mintemp]))
+            else:
+                return increasingresults

--- a/openest/test/curves/test_ucurve.py
+++ b/openest/test/curves/test_ucurve.py
@@ -1,0 +1,58 @@
+import time
+import numpy as np
+from openest.curves import basic, ushape_analytic, ushape_numeric
+
+curve = basic.ZeroInterceptPolynomialCurve([-10, 30], [1, 1, -.03]) # u-shaped to about 22
+
+fillxxs = np.arange(-10, 30)
+fillyys = curve(fillxxs)
+
+ucurve_old = ushape_numeric.UShapedCurve(curve, 0, lambda x: x, ordered=False, fillxxs=fillxxs, fillyys=fillyys)
+ucurve_new = ushape_numeric.UShapedCurve(curve, 0, lambda x: x, ordered='maintain', fillxxs=fillxxs, fillyys=fillyys)
+
+#tas = 40 * np.random.sample(100) - 10 # -10 to 30
+#tas = np.array([1, 30, 2, 35, 3, 40])
+tas = 40 * np.random.sample(100) - 10 # -10 to 30
+
+results_old = ucurve_old(tas)
+results_new = ucurve_new(tas)
+
+## Check that same results from old version
+assert sorted(results_old) == sorted(results_new)
+
+## Check that all values match up to plateau
+hiplateau = None
+loplateau = None
+for ii in range(len(tas)):
+    if results_new[ii] != curve(tas[ii]):
+        if tas[ii] > 0:
+            if hiplateau is None:
+                hiplateau = results_new[ii]
+            else:
+                assert results_new[ii] == hiplateau
+        else:
+            if loplateau is None:
+                loplateau = results_new[ii]
+            else:
+                assert results_new[ii] == loplateau
+
+ucurveclip_old = ushape_numeric.UShapedClipping(ucurve_old, curve, 0, lambda x: x, ordered=False)
+ucurveclip_new = ushape_numeric.UShapedClipping(ucurve_new, curve, 0, lambda x: x, ordered='maintain')
+
+results_old = ucurveclip_old(tas)
+results_new = ucurveclip_new(tas)
+
+## Check that same results from old version
+assert sorted(results_old) == sorted(results_new)
+
+## Check that all values match up to plateau
+hiplateau = None
+for ii in range(len(tas)):
+    if curve(tas[ii]) < 0:
+        assert results_new[ii] == 0
+    elif results_new[ii] != curve(tas[ii]):
+        if hiplateau is None:
+            hiplateau = results_new[ii]
+        else:
+            assert results_new[ii] == hiplateau
+


### PR DESCRIPTION
This maintains the order of values coming out of u-shaped curves to match the temperatures that went in. This is needed for linear extrapolation. The default `ordered` argument is now set to `maintain` which has this functionality. 

I plan on removing the old functionality, and the `ordered` argument in the future, but it is useful now as a test of the new code.