### PR TITLE
Workaround for CI/CD scipy segfault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
         - CONDA_ENV=py37
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ os:
 language: python
 notifications:
   email: false
-env:
-  - CONDA_ENV=py37
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.8
+      env:
+        - CONDA_ENV=py37
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ install:
   - source activate test_env
   - pip install .
   - conda list
-  - conda install scipy=1.4
 
 script:
   - pytest --pyargs openest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,8 @@ os:
 language: python
 notifications:
   email: false
-
-matrix:
-  fast_finish: true
-  include:
-    - python: 3.8
-      env:
-        - CONDA_ENV=py37
+env:
+  - CONDA_ENV=py37
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 language: python
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - conda env create -q -f ci/requirements-$CONDA_ENV.yml
   - source activate test_env
   - pip install .
+  - conda list
 
 script:
   - pytest --pyargs openest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-os:
-  - linux
-  - osx
+dist: bionic
 language: python
 notifications:
   email: false
@@ -11,10 +9,14 @@ matrix:
     - python: 3.8
       env:
         - CONDA_ENV=py37
+        - JOB_OS=Linux
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-$JOB_OS-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-$JOB_OS-x86_64.sh -O miniconda.sh;
+    fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
         - CONDA_ENV=py37
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - source activate test_env
   - pip install .
   - conda list
+  - conda install scipy=1.4
 
 script:
   - pytest --pyargs openest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-dist: bionic
+os:
+  - linux
+  - osx
 language: python
 notifications:
   email: false
@@ -9,14 +11,10 @@ matrix:
     - python: 3.8
       env:
         - CONDA_ENV=py37
-        - JOB_OS=Linux
 
 before_install:
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-$JOB_OS-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-$JOB_OS-x86_64.sh -O miniconda.sh;
-    fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -1,7 +1,7 @@
 name: test_env
 channels:
-  - conda-forge
   - defaults
+  - conda-forge
 dependencies:
   - python=3.7
   - numpy

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -1,7 +1,6 @@
 name: test_env
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.7
   - numpy

--- a/ci/requirements-py37.yml
+++ b/ci/requirements-py37.yml
@@ -1,6 +1,7 @@
 name: test_env
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.7
   - numpy


### PR DESCRIPTION
Looks like `master` CI/CD tests have been failing starting with https://travis-ci.org/github/ClimateImpactLab/open-estimate/builds/703234047.

This PR is to see if I can find a workaround without cluttering the repo.

Raw build log from failing tests is:
```
travis_fold:start:worker_info
[0K[33;1mWorker information[0m
hostname: 91b3b42a-6d5f-40f0-8c15-1c51e6b8c376@1.worker-org-69b85cc685-cw2xx.gce-production-1
version: v6.2.17 https://github.com/travis-ci/worker/tree/bc420764f334fe0d096a417c80426f672f1b7d18
instance: travis-job-9a71eab1-1674-46a9-9176-ff625a02d67a travis-ci-sardonyx-xenial-1553530528-f909ac5 (via amqp)
startup: 16.33895776s
travis_fold:end:worker_info
[0Ktravis_time:start:1b0d5f14
[0Ktravis_time:end:1b0d5f14:start=1593451007392167063,finish=1593451007540894454,duration=148727391,event=no_world_writable_dirs
[0Ktravis_time:start:11f7a90e
[0Ktravis_time:end:11f7a90e:start=1593451007544158439,finish=1593451007550996675,duration=6838236,event=agent
[0Ktravis_time:start:08ed865a
[0Ktravis_time:end:08ed865a:start=1593451007553896505,finish=1593451007556151536,duration=2255031,event=check_unsupported
[0Ktravis_time:start:025b9ff0
[0Ktravis_fold:start:system_info
[0K[33;1mBuild system information[0m
Build language: python
Build dist: xenial
Build id: 703234047
Job id: 703234048
Runtime kernel version: 4.15.0-1028-gcp
travis-build version: 8e9c8035
[34m[1mBuild image provisioning date and time[0m
Mon Mar 25 16:43:24 UTC 2019
[34m[1mOperating System Details[0m
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.6 LTS
Release:	16.04
Codename:	xenial
[34m[1mSystemd Version[0m
systemd 229
[34m[1mCookbooks Version[0m
42e42e4 https://github.com/travis-ci/travis-cookbooks/tree/42e42e4
[34m[1mgit version[0m
git version 2.21.0
[34m[1mbash version[0m
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
[34m[1mgcc version[0m
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
[34m[1mdocker version[0m
Client:
 Version:           18.06.0-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        0ffa825
 Built:             Wed Jul 18 19:11:02 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.0-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       0ffa825
  Built:            Wed Jul 18 19:09:05 2018
  OS/Arch:          linux/amd64
  Experimental:     false
[34m[1mclang version[0m
clang version 7.0.0 (tags/RELEASE_700/final)
[34m[1mjq version[0m
jq-1.5
[34m[1mbats version[0m
Bats 0.4.0
[34m[1mshellcheck version[0m
0.6.0
[34m[1mshfmt version[0m
v2.6.3
[34m[1mccache version[0m
3.2.4
[34m[1mcmake version[0m
cmake version 3.12.4
[34m[1mheroku version[0m
heroku/7.22.7 linux-x64 node-v11.10.1
[34m[1mimagemagick version[0m
Version: ImageMagick 6.8.9-9 Q16 x86_64 2018-09-28 http://www.imagemagick.org
[34m[1mmd5deep version[0m
4.4
[34m[1mmercurial version[0m
version 4.8
[34m[1mmysql version[0m
mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper
[34m[1mopenssl version[0m
OpenSSL 1.0.2g  1 Mar 2016
[34m[1mpacker version[0m
1.3.3
[34m[1mpostgresql client version[0m
psql (PostgreSQL) 10.7 (Ubuntu 10.7-1.pgdg16.04+1)
[34m[1mragel version[0m
Ragel State Machine Compiler version 6.8 Feb 2013
[34m[1msudo version[0m
1.8.16
[34m[1mgzip version[0m
gzip 1.6
[34m[1mzip version[0m
Zip 3.0
[34m[1mvim version[0m
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:44:48)
[34m[1miptables version[0m
iptables v1.6.0
[34m[1mcurl version[0m
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
[34m[1mwget version[0m
GNU Wget 1.17.1 built on linux-gnu.
[34m[1mrsync version[0m
rsync  version 3.1.1  protocol version 31
[34m[1mgimme version[0m
v1.5.3
[34m[1mnvm version[0m
0.34.0
[34m[1mperlbrew version[0m
/home/travis/perl5/perlbrew/bin/perlbrew  - App::perlbrew/0.86
[34m[1mphpenv version[0m
rbenv 1.1.2
[34m[1mrvm version[0m
rvm 1.29.7 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
[34m[1mdefault ruby version[0m
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
[34m[1mCouchDB version[0m
couchdb 1.6.1
[34m[1mElasticSearch version[0m
5.5.0
[34m[1mInstalled Firefox version[0m
firefox 63.0.1
[34m[1mMongoDB version[0m
MongoDB 4.0.7
[34m[1mPhantomJS version[0m
2.1.1
[34m[1mPre-installed PostgreSQL versions[0m
9.4.21
9.5.16
9.6.12
[34m[1mRedis version[0m
redis-server 5.0.4
[34m[1mPre-installed Go versions[0m
1.11.1
[34m[1mmvn version[0m
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z)
[34m[1mgradle version[0m
Gradle 4.10.2!
[34m[1mlein version[0m
Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM
[34m[1mPre-installed Node.js versions[0m
v10.15.3
v11.0.0
v4.9.1
v6.17.0
v8.12.0
v8.15.1
v8.9
[34m[1mphpenv versions[0m
  system
  5.6
  5.6.40
  7.1
  7.1.27
  7.2
* 7.2.15 (set by /home/travis/.phpenv/version)
  hhvm
  hhvm-stable
[34m[1mcomposer --version[0m
Composer version 1.8.4 2019-02-11 10:52:10
[34m[1mPre-installed Ruby versions[0m
ruby-2.3.8
ruby-2.4.5
ruby-2.5.3
travis_fold:end:system_info
[0K
travis_time:end:025b9ff0:start=1593451007558866287,finish=1593451007566713615,duration=7847328,event=show_system_info
[0Ktravis_time:start:0ea12912
[0Ktravis_time:end:0ea12912:start=1593451007571737389,finish=1593451007583516057,duration=11778668,event=rm_riak_source
[0Ktravis_time:start:008f5d8b
[0Ktravis_time:end:008f5d8b:start=1593451007586761659,finish=1593451007593385930,duration=6624271,event=fix_rwky_redis
[0Ktravis_time:start:020a5d00
[0Ktravis_time:end:020a5d00:start=1593451007596591801,finish=1593451008038090981,duration=441499180,event=wait_for_network
[0Ktravis_time:start:0c28d0dc
[0Ktravis_time:end:0c28d0dc:start=1593451008041113480,finish=1593451008235002786,duration=193889306,event=update_apt_keys
[0Ktravis_time:start:04cf5ea8
[0Ktravis_time:end:04cf5ea8:start=1593451008238159145,finish=1593451008292229020,duration=54069875,event=fix_hhvm_source
[0Ktravis_time:start:0eb1ea1e
[0Ktravis_time:end:0eb1ea1e:start=1593451008295574257,finish=1593451008298175388,duration=2601131,event=update_mongo_arch
[0Ktravis_time:start:2cb8e04b
[0Ktravis_time:end:2cb8e04b:start=1593451008301108967,finish=1593451008343298049,duration=42189082,event=fix_sudo_enabled_trusty
[0Ktravis_time:start:01cd14b0
[0Ktravis_time:end:01cd14b0:start=1593451008346726963,finish=1593451008349196610,duration=2469647,event=update_glibc
[0Ktravis_time:start:034e3a60
[0Ktravis_time:end:034e3a60:start=1593451008352339337,finish=1593451008360564594,duration=8225257,event=clean_up_path
[0Ktravis_time:start:1f15df08
[0Ktravis_time:end:1f15df08:start=1593451008363449869,finish=1593451008371078988,duration=7629119,event=fix_resolv_conf
[0Ktravis_time:start:1e90cff0
[0Ktravis_time:end:1e90cff0:start=1593451008373888075,finish=1593451008382241906,duration=8353831,event=fix_etc_hosts
[0Ktravis_time:start:0876a121
[0Ktravis_time:end:0876a121:start=1593451008385158876,finish=1593451008393697822,duration=8538946,event=fix_mvn_settings_xml
[0Ktravis_time:start:1ee6b902
[0Ktravis_time:end:1ee6b902:start=1593451008396616812,finish=1593451008405957361,duration=9340549,event=no_ipv6_localhost
[0Ktravis_time:start:2fadeb9e
[0Ktravis_time:end:2fadeb9e:start=1593451008409076969,finish=1593451008411308973,duration=2232004,event=fix_etc_mavenrc
[0Ktravis_time:start:090caf41
[0Ktravis_time:end:090caf41:start=1593451008414169523,finish=1593451008417107874,duration=2938351,event=fix_wwdr_certificate
[0Ktravis_time:start:2e3ed2db
[0Ktravis_time:end:2e3ed2db:start=1593451008419940137,finish=1593451008442872775,duration=22932638,event=put_localhost_first
[0Ktravis_time:start:0945d248
[0Ktravis_time:end:0945d248:start=1593451008445970952,finish=1593451008448628291,duration=2657339,event=home_paths
[0Ktravis_time:start:1347ed90
[0Ktravis_time:end:1347ed90:start=1593451008451588004,finish=1593451008463874078,duration=12286074,event=disable_initramfs
[0Ktravis_time:start:29da86f0
[0Ktravis_time:end:29da86f0:start=1593451008467223396,finish=1593451008747419787,duration=280196391,event=disable_ssh_roaming
[0Ktravis_time:start:116f3826
[0Ktravis_time:end:116f3826:start=1593451008750647261,finish=1593451008752913391,duration=2266130,event=debug_tools
[0Ktravis_time:start:07841727
[0Ktravis_time:end:07841727:start=1593451008755774278,finish=1593451008758652385,duration=2878107,event=uninstall_oclint
[0Ktravis_time:start:00b3f8a5
[0Ktravis_time:end:00b3f8a5:start=1593451008761584223,finish=1593451008764514782,duration=2930559,event=rvm_use
[0Ktravis_time:start:1afe3a08
[0Ktravis_time:end:1afe3a08:start=1593451008767555831,finish=1593451008774891625,duration=7335794,event=rm_etc_boto_cfg
[0Ktravis_time:start:27c0e7de
[0Ktravis_time:end:27c0e7de:start=1593451008777760475,finish=1593451008780540877,duration=2780402,event=rm_oraclejdk8_symlink
[0Ktravis_time:start:0280e530
[0Ktravis_time:end:0280e530:start=1593451008783376008,finish=1593451008892184240,duration=108808232,event=enable_i386
[0Ktravis_time:start:0f139e90
[0Ktravis_time:end:0f139e90:start=1593451008895525718,finish=1593451008900488464,duration=4962746,event=update_rubygems
[0Ktravis_time:start:04196d1c
[0Ktravis_time:end:04196d1c:start=1593451008903393937,finish=1593451009690632509,duration=787238572,event=ensure_path_components
[0Ktravis_time:start:0d6bce10
[0Ktravis_time:end:0d6bce10:start=1593451009693850328,finish=1593451009696050867,duration=2200539,event=redefine_curl
[0Ktravis_time:start:3060a1c8
[0Ktravis_time:end:3060a1c8:start=1593451009699081210,finish=1593451009701308972,duration=2227762,event=nonblock_pipe
[0Ktravis_time:start:0ff488c8
[0Ktravis_time:end:0ff488c8:start=1593451009704220644,finish=1593451015737483473,duration=6033262829,event=apt_get_update
[0Ktravis_time:start:08486ba8
[0Ktravis_time:end:08486ba8:start=1593451015741589892,finish=1593451015743863273,duration=2273381,event=deprecate_xcode_64
[0Ktravis_time:start:308f02ab
[0Ktravis_time:end:308f02ab:start=1593451015747222503,finish=1593451018264282698,duration=2517060195,event=update_heroku
[0Ktravis_time:start:041ebba0
[0Ktravis_time:end:041ebba0:start=1593451018267567437,finish=1593451018269826937,duration=2259500,event=shell_session_update
[0Ktravis_time:start:0d08b7c0
[0Ktravis_fold:start:docker_mtu
[0Ktravis_fold:end:docker_mtu
[0Ktravis_time:end:0d08b7c0:start=1593451018272673769,finish=1593451020546544670,duration=2273870901,event=set_docker_mtu
[0Ktravis_time:start:32d5b4b0
[0Ktravis_fold:start:resolvconf
[0Ktravis_fold:end:resolvconf
[0Ktravis_time:end:32d5b4b0:start=1593451020550037266,finish=1593451020612612266,duration=62575000,event=resolvconf
[0Ktravis_time:start:0e226dca
[0Ktravis_time:end:0e226dca:start=1593451020616243062,finish=1593451020774409017,duration=158165955,event=maven_central_mirror
[0Ktravis_time:start:02214210
[0Ktravis_time:end:02214210:start=1593451020777774159,finish=1593451020874955276,duration=97181117,event=maven_https
[0K[33;1m3.8 is not installed; attempting download[0m
[33;1mDownloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-3.8.tar.bz2[0m
travis_time:start:32157afb
[0K$ curl -sSf --retry 5 -o python-3.8.tar.bz2 ${archive_url}
travis_time:end:32157afb:start=1593451020975323745,finish=1593451021506158600,duration=530834855,event=configure
[0Ktravis_time:start:0ac4b585
[0K$ sudo tar xjf python-3.8.tar.bz2 --directory /
travis_time:end:0ac4b585:start=1593451021509923866,finish=1593451035018938491,duration=13509014625,event=configure
[0Ktravis_time:start:0062de9a
[0Ktravis_time:end:0062de9a:start=1593451035039036163,finish=1593451035041527453,duration=2491290,event=fix_ps4
[0Ktravis_time:start:0250c93f
[0K
travis_fold:start:git.checkout
[0Ktravis_time:start:0bb4ab56
[0K$ git clone --depth=50 --branch=master https://github.com/ClimateImpactLab/open-estimate.git ClimateImpactLab/open-estimate
Cloning into 'ClimateImpactLab/open-estimate'...
remote: Enumerating objects: 1416, done.[K
remote: Counting objects:   0% (1/1416)[K
remote: Counting objects:   1% (15/1416)[K
remote: Counting objects:   2% (29/1416)[K
remote: Counting objects:   3% (43/1416)[K
remote: Counting objects:   4% (57/1416)[K
remote: Counting objects:   5% (71/1416)[K
remote: Counting objects:   6% (85/1416)[K
remote: Counting objects:   7% (100/1416)[K
remote: Counting objects:   8% (114/1416)[K
remote: Counting objects:   9% (128/1416)[K
remote: Counting objects:  10% (142/1416)[K
remote: Counting objects:  11% (156/1416)[K
remote: Counting objects:  12% (170/1416)[K
remote: Counting objects:  13% (185/1416)[K
remote: Counting objects:  14% (199/1416)[K
remote: Counting objects:  15% (213/1416)[K
remote: Counting objects:  16% (227/1416)[K
remote: Counting objects:  17% (241/1416)[K
remote: Counting objects:  18% (255/1416)[K
remote: Counting objects:  19% (270/1416)[K
remote: Counting objects:  20% (284/1416)[K
remote: Counting objects:  21% (298/1416)[K
remote: Counting objects:  22% (312/1416)[K
remote: Counting objects:  23% (326/1416)[K
remote: Counting objects:  24% (340/1416)[K
remote: Counting objects:  25% (354/1416)[K
remote: Counting objects:  26% (369/1416)[K
remote: Counting objects:  27% (383/1416)[K
remote: Counting objects:  28% (397/1416)[K
remote: Counting objects:  29% (411/1416)[K
remote: Counting objects:  30% (425/1416)[K
remote: Counting objects:  31% (439/1416)[K
remote: Counting objects:  32% (454/1416)[K
remote: Counting objects:  33% (468/1416)[K
remote: Counting objects:  34% (482/1416)[K
remote: Counting objects:  35% (496/1416)[K
remote: Counting objects:  36% (510/1416)[K
remote: Counting objects:  37% (524/1416)[K
remote: Counting objects:  38% (539/1416)[K
remote: Counting objects:  39% (553/1416)[K
remote: Counting objects:  40% (567/1416)[K
remote: Counting objects:  41% (581/1416)[K
remote: Counting objects:  42% (595/1416)[K
remote: Counting objects:  43% (609/1416)[K
remote: Counting objects:  44% (624/1416)[K
remote: Counting objects:  45% (638/1416)[K
remote: Counting objects:  46% (652/1416)[K
remote: Counting objects:  47% (666/1416)[K
remote: Counting objects:  48% (680/1416)[K
remote: Counting objects:  49% (694/1416)[K
remote: Counting objects:  50% (708/1416)[K
remote: Counting objects:  51% (723/1416)[K
remote: Counting objects:  52% (737/1416)[K
remote: Counting objects:  53% (751/1416)[K
remote: Counting objects:  54% (765/1416)[K
remote: Counting objects:  55% (779/1416)[K
remote: Counting objects:  56% (793/1416)[K
remote: Counting objects:  57% (808/1416)[K
remote: Counting objects:  58% (822/1416)[K
remote: Counting objects:  59% (836/1416)[K
remote: Counting objects:  60% (850/1416)[K
remote: Counting objects:  61% (864/1416)[K
remote: Counting objects:  62% (878/1416)[K
remote: Counting objects:  63% (893/1416)[K
remote: Counting objects:  64% (907/1416)[K
remote: Counting objects:  65% (921/1416)[K
remote: Counting objects:  66% (935/1416)[K
remote: Counting objects:  67% (949/1416)[K
remote: Counting objects:  68% (963/1416)[K
remote: Counting objects:  69% (978/1416)[K
remote: Counting objects:  70% (992/1416)[K
remote: Counting objects:  71% (1006/1416)[K
remote: Counting objects:  72% (1020/1416)[K
remote: Counting objects:  73% (1034/1416)[K
remote: Counting objects:  74% (1048/1416)[K
remote: Counting objects:  75% (1062/1416)[K
remote: Counting objects:  76% (1077/1416)[K
remote: Counting objects:  77% (1091/1416)[K
remote: Counting objects:  78% (1105/1416)[K
remote: Counting objects:  79% (1119/1416)[K
remote: Counting objects:  80% (1133/1416)[K
remote: Counting objects:  81% (1147/1416)[K
remote: Counting objects:  82% (1162/1416)[K
remote: Counting objects:  83% (1176/1416)[K
remote: Counting objects:  84% (1190/1416)[K
remote: Counting objects:  85% (1204/1416)[K
remote: Counting objects:  86% (1218/1416)[K
remote: Counting objects:  87% (1232/1416)[K
remote: Counting objects:  88% (1247/1416)[K
remote: Counting objects:  89% (1261/1416)[K
remote: Counting objects:  90% (1275/1416)[K
remote: Counting objects:  91% (1289/1416)[K
remote: Counting objects:  92% (1303/1416)[K
remote: Counting objects:  93% (1317/1416)[K
remote: Counting objects:  94% (1332/1416)[K
remote: Counting objects:  95% (1346/1416)[K
remote: Counting objects:  96% (1360/1416)[K
remote: Counting objects:  97% (1374/1416)[K
remote: Counting objects:  98% (1388/1416)[K
remote: Counting objects:  99% (1402/1416)[K
remote: Counting objects: 100% (1416/1416)[K
remote: Counting objects: 100% (1416/1416), done.[K
remote: Compressing objects:   0% (1/510)[K
remote: Compressing objects:   1% (6/510)[K
remote: Compressing objects:   2% (11/510)[K
remote: Compressing objects:   3% (16/510)[K
remote: Compressing objects:   4% (21/510)[K
remote: Compressing objects:   5% (26/510)[K
remote: Compressing objects:   6% (31/510)[K
remote: Compressing objects:   7% (36/510)[K
remote: Compressing objects:   8% (41/510)[K
remote: Compressing objects:   9% (46/510)[K
remote: Compressing objects:  10% (51/510)[K
remote: Compressing objects:  11% (57/510)[K
remote: Compressing objects:  12% (62/510)[K
remote: Compressing objects:  13% (67/510)[K
remote: Compressing objects:  14% (72/510)[K
remote: Compressing objects:  15% (77/510)[K
remote: Compressing objects:  16% (82/510)[K
remote: Compressing objects:  17% (87/510)[K
remote: Compressing objects:  18% (92/510)[K
remote: Compressing objects:  19% (97/510)[K
remote: Compressing objects:  20% (102/510)[K
remote: Compressing objects:  21% (108/510)[K
remote: Compressing objects:  22% (113/510)[K
remote: Compressing objects:  23% (118/510)[K
remote: Compressing objects:  24% (123/510)[K
remote: Compressing objects:  25% (128/510)[K
remote: Compressing objects:  26% (133/510)[K
remote: Compressing objects:  27% (138/510)[K
remote: Compressing objects:  28% (143/510)[K
remote: Compressing objects:  29% (148/510)[K
remote: Compressing objects:  30% (153/510)[K
remote: Compressing objects:  31% (159/510)[K
remote: Compressing objects:  32% (164/510)[K
remote: Compressing objects:  33% (169/510)[K
remote: Compressing objects:  34% (174/510)[K
remote: Compressing objects:  35% (179/510)[K
remote: Compressing objects:  36% (184/510)[K
remote: Compressing objects:  37% (189/510)[K
remote: Compressing objects:  38% (194/510)[K
remote: Compressing objects:  39% (199/510)[K
remote: Compressing objects:  40% (204/510)[K
remote: Compressing objects:  41% (210/510)[K
remote: Compressing objects:  42% (215/510)[K
remote: Compressing objects:  43% (220/510)[K
remote: Compressing objects:  44% (225/510)[K
remote: Compressing objects:  45% (230/510)[K
remote: Compressing objects:  46% (235/510)[K
remote: Compressing objects:  47% (240/510)[K
remote: Compressing objects:  48% (245/510)[K
remote: Compressing objects:  49% (250/510)[K
remote: Compressing objects:  50% (255/510)[K
remote: Compressing objects:  51% (261/510)[K
remote: Compressing objects:  52% (266/510)[K
remote: Compressing objects:  53% (271/510)[K
remote: Compressing objects:  54% (276/510)[K
remote: Compressing objects:  55% (281/510)[K
remote: Compressing objects:  56% (286/510)[K
remote: Compressing objects:  57% (291/510)[K
remote: Compressing objects:  58% (296/510)[K
remote: Compressing objects:  59% (301/510)[K
remote: Compressing objects:  60% (306/510)[K
remote: Compressing objects:  61% (312/510)[K
remote: Compressing objects:  62% (317/510)[K
remote: Compressing objects:  63% (322/510)[K
remote: Compressing objects:  64% (327/510)[K
remote: Compressing objects:  65% (332/510)[K
remote: Compressing objects:  66% (337/510)[K
remote: Compressing objects:  67% (342/510)[K
remote: Compressing objects:  68% (347/510)[K
remote: Compressing objects:  69% (352/510)[K
remote: Compressing objects:  70% (357/510)[K
remote: Compressing objects:  71% (363/510)[K
remote: Compressing objects:  72% (368/510)[K
remote: Compressing objects:  73% (373/510)[K
remote: Compressing objects:  74% (378/510)[K
remote: Compressing objects:  75% (383/510)[K
remote: Compressing objects:  76% (388/510)[K
remote: Compressing objects:  77% (393/510)[K
remote: Compressing objects:  78% (398/510)[K
remote: Compressing objects:  79% (403/510)[K
remote: Compressing objects:  80% (408/510)[K
remote: Compressing objects:  81% (414/510)[K
remote: Compressing objects:  82% (419/510)[K
remote: Compressing objects:  83% (424/510)[K
remote: Compressing objects:  84% (429/510)[K
remote: Compressing objects:  85% (434/510)[K
remote: Compressing objects:  86% (439/510)[K
remote: Compressing objects:  87% (444/510)[K
remote: Compressing objects:  88% (449/510)[K
remote: Compressing objects:  89% (454/510)[K
remote: Compressing objects:  90% (459/510)[K
remote: Compressing objects:  91% (465/510)[K
remote: Compressing objects:  92% (470/510)[K
remote: Compressing objects:  93% (475/510)[K
remote: Compressing objects:  94% (480/510)[K
remote: Compressing objects:  95% (485/510)[K
remote: Compressing objects:  96% (490/510)[K
remote: Compressing objects:  97% (495/510)[K
remote: Compressing objects:  98% (500/510)[K
remote: Compressing objects:  99% (505/510)[K
remote: Compressing objects: 100% (510/510)[K
remote: Compressing objects: 100% (510/510), done.[K
Receiving objects:   0% (1/1416)   
Receiving objects:   1% (15/1416)   
Receiving objects:   2% (29/1416)   
Receiving objects:   3% (43/1416)   
Receiving objects:   4% (57/1416)   
Receiving objects:   5% (71/1416)   
Receiving objects:   6% (85/1416)   
Receiving objects:   7% (100/1416)   
Receiving objects:   8% (114/1416)   
Receiving objects:   9% (128/1416)   
Receiving objects:  10% (142/1416)   
Receiving objects:  11% (156/1416)   
Receiving objects:  12% (170/1416)   
Receiving objects:  13% (185/1416)   
Receiving objects:  14% (199/1416)   
Receiving objects:  15% (213/1416)   
Receiving objects:  16% (227/1416)   
Receiving objects:  17% (241/1416)   
Receiving objects:  18% (255/1416)   
Receiving objects:  19% (270/1416)   
Receiving objects:  20% (284/1416)   
Receiving objects:  21% (298/1416)   
Receiving objects:  22% (312/1416)   
Receiving objects:  23% (326/1416)   
Receiving objects:  24% (340/1416)   
Receiving objects:  25% (354/1416)   
Receiving objects:  26% (369/1416)   
Receiving objects:  27% (383/1416)   
Receiving objects:  28% (397/1416)   
Receiving objects:  29% (411/1416)   
Receiving objects:  30% (425/1416)   
Receiving objects:  31% (439/1416)   
Receiving objects:  32% (454/1416)   
Receiving objects:  33% (468/1416)   
Receiving objects:  34% (482/1416)   
Receiving objects:  35% (496/1416)   
Receiving objects:  36% (510/1416)   
Receiving objects:  37% (524/1416)   
Receiving objects:  38% (539/1416)   
Receiving objects:  39% (553/1416)   
Receiving objects:  40% (567/1416)   
Receiving objects:  41% (581/1416)   
Receiving objects:  42% (595/1416)   
Receiving objects:  43% (609/1416)   
Receiving objects:  44% (624/1416)   
Receiving objects:  45% (638/1416)   
Receiving objects:  46% (652/1416)   
Receiving objects:  47% (666/1416)   
Receiving objects:  48% (680/1416)   
Receiving objects:  49% (694/1416)   
Receiving objects:  50% (708/1416)   
Receiving objects:  51% (723/1416)   
Receiving objects:  52% (737/1416)   
Receiving objects:  53% (751/1416)   
Receiving objects:  54% (765/1416)   
Receiving objects:  55% (779/1416)   
Receiving objects:  56% (793/1416)   
Receiving objects:  57% (808/1416)   
Receiving objects:  58% (822/1416)   
Receiving objects:  59% (836/1416)   
Receiving objects:  60% (850/1416)   
Receiving objects:  61% (864/1416)   
Receiving objects:  62% (878/1416)   
Receiving objects:  63% (893/1416)   
Receiving objects:  64% (907/1416)   
Receiving objects:  65% (921/1416)   
Receiving objects:  66% (935/1416)   
Receiving objects:  67% (949/1416)   
Receiving objects:  68% (963/1416)   
Receiving objects:  69% (978/1416)   
Receiving objects:  70% (992/1416)   
Receiving objects:  71% (1006/1416)   
Receiving objects:  72% (1020/1416)   
remote: Total 1416 (delta 945), reused 1275 (delta 873), pack-reused 0[K
Receiving objects:  73% (1034/1416)   
Receiving objects:  74% (1048/1416)   
Receiving objects:  75% (1062/1416)   
Receiving objects:  76% (1077/1416)   
Receiving objects:  77% (1091/1416)   
Receiving objects:  78% (1105/1416)   
Receiving objects:  79% (1119/1416)   
Receiving objects:  80% (1133/1416)   
Receiving objects:  81% (1147/1416)   
Receiving objects:  82% (1162/1416)   
Receiving objects:  83% (1176/1416)   
Receiving objects:  84% (1190/1416)   
Receiving objects:  85% (1204/1416)   
Receiving objects:  86% (1218/1416)   
Receiving objects:  87% (1232/1416)   
Receiving objects:  88% (1247/1416)   
Receiving objects:  89% (1261/1416)   
Receiving objects:  90% (1275/1416)   
Receiving objects:  91% (1289/1416)   
Receiving objects:  92% (1303/1416)   
Receiving objects:  93% (1317/1416)   
Receiving objects:  94% (1332/1416)   
Receiving objects:  95% (1346/1416)   
Receiving objects:  96% (1360/1416)   
Receiving objects:  97% (1374/1416)   
Receiving objects:  98% (1388/1416)   
Receiving objects:  99% (1402/1416)   
Receiving objects: 100% (1416/1416)   
Receiving objects: 100% (1416/1416), 345.91 KiB | 6.29 MiB/s, done.
Resolving deltas:   0% (0/945)   
Resolving deltas:   6% (65/945)   
Resolving deltas:  21% (207/945)   
Resolving deltas:  22% (209/945)   
Resolving deltas:  23% (220/945)   
Resolving deltas:  24% (229/945)   
Resolving deltas:  25% (242/945)   
Resolving deltas:  27% (256/945)   
Resolving deltas:  30% (286/945)   
Resolving deltas:  32% (305/945)   
Resolving deltas:  33% (312/945)   
Resolving deltas:  36% (341/945)   
Resolving deltas:  37% (351/945)   
Resolving deltas:  44% (419/945)   
Resolving deltas:  53% (505/945)   
Resolving deltas:  54% (515/945)   
Resolving deltas:  59% (562/945)   
Resolving deltas:  60% (568/945)   
Resolving deltas:  61% (577/945)   
Resolving deltas:  62% (587/945)   
Resolving deltas:  63% (597/945)   
Resolving deltas:  64% (607/945)   
Resolving deltas:  67% (642/945)   
Resolving deltas:  68% (645/945)   
Resolving deltas:  69% (658/945)   
Resolving deltas:  70% (669/945)   
Resolving deltas:  72% (688/945)   
Resolving deltas:  73% (691/945)   
Resolving deltas:  74% (705/945)   
Resolving deltas:  77% (732/945)   
Resolving deltas:  78% (740/945)   
Resolving deltas:  79% (748/945)   
Resolving deltas:  83% (791/945)   
Resolving deltas:  84% (796/945)   
Resolving deltas:  85% (804/945)   
Resolving deltas:  86% (813/945)   
Resolving deltas:  87% (823/945)   
Resolving deltas:  88% (839/945)   
Resolving deltas:  89% (845/945)   
Resolving deltas:  90% (853/945)   
Resolving deltas:  91% (862/945)   
Resolving deltas:  92% (871/945)   
Resolving deltas:  93% (879/945)   
Resolving deltas:  94% (889/945)   
Resolving deltas:  95% (901/945)   
Resolving deltas:  96% (909/945)   
Resolving deltas:  97% (923/945)   
Resolving deltas:  99% (937/945)   
Resolving deltas: 100% (945/945)   
Resolving deltas: 100% (945/945), done.
travis_time:end:0bb4ab56:start=1593451035048627045,finish=1593451035684748819,duration=636121774,event=checkout
[0K$ cd ClimateImpactLab/open-estimate
$ git checkout -qf d5cc89319377b421231751d193b3fd58c1836e58
travis_fold:end:git.checkout
[0K
travis_fold:start:git.submodule
[0Ktravis_time:start:28175af0
[0K$ git submodule update --init --recursive
travis_time:end:28175af0:start=1593451035700691700,finish=1593451035729957665,duration=29265965,event=checkout
[0Ktravis_fold:end:git.submodule
[0Ktravis_time:end:28175af0:start=1593451035700691700,finish=1593451035732698282,duration=32006582,event=checkout
[0Ktravis_time:start:0201d3e0
[0K
[33;1mSetting environment variables from .travis.yml[0m
$ export CONDA_ENV=py37
$ export JOB_OS=Linux

travis_time:end:0201d3e0:start=1593451035735853556,finish=1593451035742063237,duration=6209681,event=env
[0Ktravis_time:start:01b299d0
[0K$ source ~/virtualenv/python3.8/bin/activate
travis_time:end:01b299d0:start=1593451035745536536,finish=1593451035750729390,duration=5192854,event=
[0K$ python --version
Python 3.8.0
$ pip --version
pip 19.3 from /home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pip (python 3.8)
travis_fold:start:before_install.1
[0Ktravis_time:start:03e40d3d
[0K$ if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-$JOB_OS-x86_64.sh -O miniconda.sh; else wget https://repo.continuum.io/miniconda/Miniconda3-latest-$JOB_OS-x86_64.sh -O miniconda.sh; fi
--2020-06-29 17:17:15--  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
Resolving repo.continuum.io (repo.continuum.io)... 104.18.200.79, 104.18.201.79, 2606:4700::6812:c84f, ...
Connecting to repo.continuum.io (repo.continuum.io)|104.18.200.79|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh [following]
--2020-06-29 17:17:16--  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
Resolving repo.anaconda.com (repo.anaconda.com)... 104.16.130.3, 104.16.131.3, 2606:4700::6810:8203, ...
Connecting to repo.anaconda.com (repo.anaconda.com)|104.16.130.3|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 88867207 (85M) [application/x-sh]
Saving to: â€˜miniconda.shâ€™


miniconda.sh          0%[                    ]       0  --.-KB/s               
miniconda.sh         35%[======>             ]  30.01M   150MB/s               
miniconda.sh         88%[================>   ]  74.99M   187MB/s               
miniconda.sh        100%[===================>]  84.75M   191MB/s    in 0.4s    

2020-06-29 17:17:16 (191 MB/s) - â€˜miniconda.shâ€™ saved [88867207/88867207]

travis_time:end:03e40d3d:start=1593451035946327133,finish=1593451036547999592,duration=601672459,event=before_install
[0Ktravis_fold:end:before_install.1
[0Ktravis_fold:start:before_install.2
[0Ktravis_time:start:02f4c0ba
[0K$ bash miniconda.sh -b -p $HOME/miniconda
PREFIX=/home/travis/miniconda
Unpacking payload ...

  0%|                                                    | 0/35 [00:00<?, ?it/s]
Extracting : chardet-3.0.4-py37_1003.conda:   0%|        | 0/35 [00:00<?, ?it/s]
Extracting : chardet-3.0.4-py37_1003.conda:   3%| | 1/35 [00:00<00:04,  8.20it/s
Extracting : conda-package-handling-1.6.1-py37h7b6447c_0.conda:   3%| | 1/35 [00
Extracting : ld_impl_linux-64-2.33.1-h53a641e_7.conda:   6%| | 2/35 [00:00<00:04
Extracting : ld_impl_linux-64-2.33.1-h53a641e_7.conda:   9%| | 3/35 [00:00<00:03
Extracting : wheel-0.34.2-py37_0.conda:   9%|â–Ž   | 3/35 [00:00<00:03,  9.88it/s]
Extracting : cffi-1.14.0-py37he30daa8_1.conda:  11%| | 4/35 [00:00<00:03,  9.88i
Extracting : cffi-1.14.0-py37he30daa8_1.conda:  14%|â–| 5/35 [00:00<00:02, 10.33i
Extracting : six-1.14.0-py37_0.conda:  14%|â–Š     | 5/35 [00:00<00:02, 10.33it/s]
Extracting : pycosat-0.6.3-py37h7b6447c_0.conda:  17%|â–| 6/35 [00:00<00:02, 10.3
Extracting : cryptography-2.9.2-py37h1ba5d50_0.conda:  20%|â–| 7/35 [00:00<00:02,
Extracting : cryptography-2.9.2-py37h1ba5d50_0.conda:  23%|â–| 8/35 [00:00<00:02,
Extracting : libffi-3.3-he6710b0_1.conda:  23%|â– | 8/35 [00:00<00:02, 12.67it/s]
Extracting : tk-8.6.8-hbc83047_0.conda:  26%|â–ˆ   | 9/35 [00:00<00:02, 12.67it/s]
Extracting : tk-8.6.8-hbc83047_0.conda:  29%|â–Š  | 10/35 [00:00<00:01, 12.84it/s]
Extracting : certifi-2020.4.5.1-py37_0.conda:  29%|â–Ž| 10/35 [00:00<00:01, 12.84i
Extracting : openssl-1.1.1g-h7b6447c_0.conda:  31%|â–Ž| 11/35 [00:00<00:01, 12.84i
Extracting : libedit-3.1.20181209-hc058e9b_0.conda:  34%|â–Ž| 12/35 [00:00<00:01, 
Extracting : libedit-3.1.20181209-hc058e9b_0.conda:  37%|â–Ž| 13/35 [00:00<00:01, 
Extracting : zlib-1.2.11-h7b6447c_3.conda:  37%|â–Ž| 13/35 [00:00<00:01, 15.49it/s
Extracting : libstdcxx-ng-9.1.0-hdf63c60_0.conda:  40%|â–| 14/35 [00:00<00:01, 15
Extracting : libstdcxx-ng-9.1.0-hdf63c60_0.conda:  43%|â–| 15/35 [00:00<00:01, 12
Extracting : pycparser-2.20-py_0.conda:  43%|â–ˆâ–Ž | 15/35 [00:00<00:01, 12.73it/s]
Extracting : ruamel_yaml-0.15.87-py37h7b6447c_0.conda:  46%|â–| 16/35 [00:01<00:0
Extracting : readline-8.0-h7b6447c_0.conda:  49%|â–| 17/35 [00:01<00:01, 12.73it/
Extracting : urllib3-1.25.8-py37_0.conda:  51%|â–Œ| 18/35 [00:01<00:01, 12.73it/s]
Extracting : urllib3-1.25.8-py37_0.conda:  54%|â–Œ| 19/35 [00:01<00:01, 15.69it/s]
Extracting : idna-2.9-py_1.conda:  54%|â–ˆâ–ˆâ–ˆâ–ˆâ–‰    | 19/35 [00:01<00:01, 15.69it/s]
Extracting : _libgcc_mutex-0.1-main.conda:  57%|â–Œ| 20/35 [00:01<00:00, 15.69it/s
Extracting : requests-2.23.0-py37_0.conda:  60%|â–Œ| 21/35 [00:01<00:00, 15.69it/s
Extracting : requests-2.23.0-py37_0.conda:  63%|â–‹| 22/35 [00:01<00:00, 16.12it/s
Extracting : pip-20.0.2-py37_3.conda:  63%|â–ˆâ–ˆâ–ˆâ– | 22/35 [00:01<00:00, 16.12it/s]
Extracting : ca-certificates-2020.1.1-0.conda:  66%|â–‹| 23/35 [00:01<00:00, 16.12
Extracting : xz-5.2.5-h7b6447c_0.conda:  69%|â–ˆâ–ˆ | 24/35 [00:01<00:00, 16.12it/s]
Extracting : xz-5.2.5-h7b6447c_0.conda:  71%|â–ˆâ–ˆâ–| 25/35 [00:01<00:00, 16.81it/s]
Extracting : tqdm-4.46.0-py_0.conda:  71%|â–ˆâ–ˆâ–ˆâ–ˆâ–Ž | 25/35 [00:01<00:00, 16.81it/s]
Extracting : python-3.7.7-hcff3b4d_5.conda:  74%|â–‹| 26/35 [00:02<00:00, 16.81it/
Extracting : python-3.7.7-hcff3b4d_5.conda:  77%|â–Š| 27/35 [00:02<00:01,  7.12it/
Extracting : pysocks-1.7.1-py37_0.conda:  77%|â–ˆâ–Œ| 27/35 [00:02<00:01,  7.12it/s]
Extracting : sqlite-3.31.1-h62c20be_1.conda:  80%|â–Š| 28/35 [00:02<00:00,  7.12it
Extracting : setuptools-46.4.0-py37_0.conda:  83%|â–Š| 29/35 [00:02<00:00,  7.12it
Extracting : pyopenssl-19.1.0-py37_0.conda:  86%|â–Š| 30/35 [00:02<00:00,  7.12it/
Extracting : ncurses-6.2-he6710b0_1.conda:  89%|â–‰| 31/35 [00:02<00:00,  7.12it/s
Extracting : yaml-0.1.7-had09818_2.conda:  91%|â–‰| 32/35 [00:02<00:00,  7.12it/s]
Extracting : libgcc-ng-9.1.0-hdf63c60_0.conda:  94%|â–‰| 33/35 [00:02<00:00,  7.12
Extracting : libgcc-ng-9.1.0-hdf63c60_0.conda:  97%|â–‰| 34/35 [00:02<00:00,  9.13
Extracting : conda-4.8.3-py37_0.tar.bz2:  97%|â–ˆâ–‰| 34/35 [00:02<00:00,  9.13it/s]
                                                                                
Collecting package metadata (current_repodata.json): - done
Solving environment: | / done

## Package Plan ##

  environment location: /home/travis/miniconda

  added / updated specs:
    - _libgcc_mutex==0.1=main
    - ca-certificates==2020.1.1=0
    - certifi==2020.4.5.1=py37_0
    - cffi==1.14.0=py37he30daa8_1
    - chardet==3.0.4=py37_1003
    - conda-package-handling==1.6.1=py37h7b6447c_0
    - conda==4.8.3=py37_0
    - cryptography==2.9.2=py37h1ba5d50_0
    - idna==2.9=py_1
    - ld_impl_linux-64==2.33.1=h53a641e_7
    - libedit==3.1.20181209=hc058e9b_0
    - libffi==3.3=he6710b0_1
    - libgcc-ng==9.1.0=hdf63c60_0
    - libstdcxx-ng==9.1.0=hdf63c60_0
    - ncurses==6.2=he6710b0_1
    - openssl==1.1.1g=h7b6447c_0
    - pip==20.0.2=py37_3
    - pycosat==0.6.3=py37h7b6447c_0
    - pycparser==2.20=py_0
    - pyopenssl==19.1.0=py37_0
    - pysocks==1.7.1=py37_0
    - python==3.7.7=hcff3b4d_5
    - readline==8.0=h7b6447c_0
    - requests==2.23.0=py37_0
    - ruamel_yaml==0.15.87=py37h7b6447c_0
    - setuptools==46.4.0=py37_0
    - six==1.14.0=py37_0
    - sqlite==3.31.1=h62c20be_1
    - tk==8.6.8=hbc83047_0
    - tqdm==4.46.0=py_0
    - urllib3==1.25.8=py37_0
    - wheel==0.34.2=py37_0
    - xz==5.2.5=h7b6447c_0
    - yaml==0.1.7=had09818_2
    - zlib==1.2.11=h7b6447c_3


The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main
  ca-certificates    pkgs/main/linux-64::ca-certificates-2020.1.1-0
  certifi            pkgs/main/linux-64::certifi-2020.4.5.1-py37_0
  cffi               pkgs/main/linux-64::cffi-1.14.0-py37he30daa8_1
  chardet            pkgs/main/linux-64::chardet-3.0.4-py37_1003
  conda              pkgs/main/linux-64::conda-4.8.3-py37_0
  conda-package-han~ pkgs/main/linux-64::conda-package-handling-1.6.1-py37h7b6447c_0
  cryptography       pkgs/main/linux-64::cryptography-2.9.2-py37h1ba5d50_0
  idna               pkgs/main/noarch::idna-2.9-py_1
  ld_impl_linux-64   pkgs/main/linux-64::ld_impl_linux-64-2.33.1-h53a641e_7
  libedit            pkgs/main/linux-64::libedit-3.1.20181209-hc058e9b_0
  libffi             pkgs/main/linux-64::libffi-3.3-he6710b0_1
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-9.1.0-hdf63c60_0
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-9.1.0-hdf63c60_0
  ncurses            pkgs/main/linux-64::ncurses-6.2-he6710b0_1
  openssl            pkgs/main/linux-64::openssl-1.1.1g-h7b6447c_0
  pip                pkgs/main/linux-64::pip-20.0.2-py37_3
  pycosat            pkgs/main/linux-64::pycosat-0.6.3-py37h7b6447c_0
  pycparser          pkgs/main/noarch::pycparser-2.20-py_0
  pyopenssl          pkgs/main/linux-64::pyopenssl-19.1.0-py37_0
  pysocks            pkgs/main/linux-64::pysocks-1.7.1-py37_0
  python             pkgs/main/linux-64::python-3.7.7-hcff3b4d_5
  readline           pkgs/main/linux-64::readline-8.0-h7b6447c_0
  requests           pkgs/main/linux-64::requests-2.23.0-py37_0
  ruamel_yaml        pkgs/main/linux-64::ruamel_yaml-0.15.87-py37h7b6447c_0
  setuptools         pkgs/main/linux-64::setuptools-46.4.0-py37_0
  six                pkgs/main/linux-64::six-1.14.0-py37_0
  sqlite             pkgs/main/linux-64::sqlite-3.31.1-h62c20be_1
  tk                 pkgs/main/linux-64::tk-8.6.8-hbc83047_0
  tqdm               pkgs/main/noarch::tqdm-4.46.0-py_0
  urllib3            pkgs/main/linux-64::urllib3-1.25.8-py37_0
  wheel              pkgs/main/linux-64::wheel-0.34.2-py37_0
  xz                 pkgs/main/linux-64::xz-5.2.5-h7b6447c_0
  yaml               pkgs/main/linux-64::yaml-0.1.7-had09818_2
  zlib               pkgs/main/linux-64::zlib-1.2.11-h7b6447c_3


Preparing transaction: \ | / done
Executing transaction: \ | / - \ | / - done
installation finished.
travis_time:end:02f4c0ba:start=1593451036552809760,finish=1593451049173655117,duration=12620845357,event=before_install
[0Ktravis_fold:end:before_install.2
[0Ktravis_fold:start:before_install.3
[0Ktravis_time:start:028a3a50
[0K$ export PATH="$HOME/miniconda/bin:$PATH"
travis_time:end:028a3a50:start=1593451049177794860,finish=1593451049180222805,duration=2427945,event=before_install
[0Ktravis_fold:end:before_install.3
[0Ktravis_fold:start:before_install.4
[0Ktravis_time:start:022e1420
[0K$ hash -r
travis_time:end:022e1420:start=1593451049184002525,finish=1593451049186148483,duration=2145958,event=before_install
[0Ktravis_fold:end:before_install.4
[0Ktravis_fold:start:before_install.5
[0Ktravis_time:start:013de8f3
[0K$ conda config --set always_yes yes --set changeps1 no
travis_time:end:013de8f3:start=1593451049189531121,finish=1593451049313312330,duration=123781209,event=before_install
[0Ktravis_fold:end:before_install.5
[0Ktravis_fold:start:before_install.6
[0Ktravis_time:start:08cbc386
[0K$ conda update -q conda
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /home/travis/miniconda

  added / updated specs:
    - conda


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    brotlipy-0.7.0             |py37h7b6447c_1000         322 KB
    certifi-2020.6.20          |           py37_0         156 KB
    libedit-3.1.20191231       |       h7b6447c_0         167 KB
    pip-20.1.1                 |           py37_1         1.7 MB
    requests-2.24.0            |             py_0          56 KB
    ruamel_yaml-0.15.87        |   py37h7b6447c_1         245 KB
    setuptools-47.3.1          |           py37_0         514 KB
    six-1.15.0                 |             py_0          13 KB
    sqlite-3.32.3              |       h62c20be_0         1.1 MB
    tk-8.6.10                  |       hbc83047_0         3.0 MB
    tqdm-4.46.1                |             py_0          60 KB
    urllib3-1.25.9             |             py_0         103 KB
    yaml-0.2.5                 |       h7b6447c_0          75 KB
    ------------------------------------------------------------
                                           Total:         7.5 MB

The following NEW packages will be INSTALLED:

  brotlipy           pkgs/main/linux-64::brotlipy-0.7.0-py37h7b6447c_1000

The following packages will be UPDATED:

  certifi                                 2020.4.5.1-py37_0 --> 2020.6.20-py37_0
  libedit                           3.1.20181209-hc058e9b_0 --> 3.1.20191231-h7b6447c_0
  pip                                         20.0.2-py37_3 --> 20.1.1-py37_1
  requests           pkgs/main/linux-64::requests-2.23.0-p~ --> pkgs/main/noarch::requests-2.24.0-py_0
  ruamel_yaml                        0.15.87-py37h7b6447c_0 --> 0.15.87-py37h7b6447c_1
  setuptools                                  46.4.0-py37_0 --> 47.3.1-py37_0
  six                 pkgs/main/linux-64::six-1.14.0-py37_0 --> pkgs/main/noarch::six-1.15.0-py_0
  sqlite                                  3.31.1-h62c20be_1 --> 3.32.3-h62c20be_0
  tk                                       8.6.8-hbc83047_0 --> 8.6.10-hbc83047_0
  tqdm                                          4.46.0-py_0 --> 4.46.1-py_0
  urllib3            pkgs/main/linux-64::urllib3-1.25.8-py~ --> pkgs/main/noarch::urllib3-1.25.9-py_0
  yaml                                     0.1.7-had09818_2 --> 0.2.5-h7b6447c_0


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
travis_time:end:08cbc386:start=1593451049317559939,finish=1593451055312370631,duration=5994810692,event=before_install
[0Ktravis_fold:end:before_install.6
[0Ktravis_fold:start:before_install.7
[0Ktravis_time:start:0a2ab180
[0K$ conda info -a

     active environment : None
       user config file : /home/travis/.condarc
 populated config files : /home/travis/.condarc
          conda version : 4.8.3
    conda-build version : not installed
         python version : 3.7.7.final.0
       virtual packages : __glibc=2.23
       base environment : /home/travis/miniconda  (writable)
           channel URLs : https://repo.anaconda.com/pkgs/main/linux-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/linux-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /home/travis/miniconda/pkgs
                          /home/travis/.conda/pkgs
       envs directories : /home/travis/miniconda/envs
                          /home/travis/.conda/envs
               platform : linux-64
             user-agent : conda/4.8.3 requests/2.24.0 CPython/3.7.7 Linux/4.15.0-1028-gcp ubuntu/16.04.5 glibc/2.23
                UID:GID : 2000:2000
             netrc file : None
           offline mode : False

# conda environments:
#
base                  *  /home/travis/miniconda

sys.version: 3.7.7 (default, May  7 2020, 21:25:33) 
...
sys.prefix: /home/travis/miniconda
sys.executable: /home/travis/miniconda/bin/python
conda location: /home/travis/miniconda/lib/python3.7/site-packages/conda
conda-build: None
conda-env: /home/travis/miniconda/bin/conda-env
user site dirs: 

CIO_TEST: <not set>
CONDA_ENV: py37
CONDA_ROOT: /home/travis/miniconda
GEM_PATH: /home/travis/.rvm/gems/ruby-2.5.3:/home/travis/.rvm/gems/ruby-2.5.3@global
GOPATH: /home/travis/gopath
MANPATH: /home/travis/.nvm/versions/node/v8.12.0/share/man:/home/travis/.rvm/rubies/ruby-2.5.3/share/man:/usr/local/cmake-3.12.4/man:/usr/local/clang-7.0.0/share/man:/usr/local/man:/usr/local/share/man:/usr/share/man:/home/travis/.rvm/man
PATH: /home/travis/miniconda/bin:/home/travis/virtualenv/python3.8.0/bin:/home/travis/bin:/home/travis/.local/bin:/usr/local/lib/jvm/openjdk11/bin:/opt/pyenv/shims:/home/travis/.phpenv/shims:/home/travis/perl5/perlbrew/bin:/home/travis/.nvm/versions/node/v8.12.0/bin:/home/travis/.rvm/gems/ruby-2.5.3/bin:/home/travis/.rvm/gems/ruby-2.5.3@global/bin:/home/travis/.rvm/rubies/ruby-2.5.3/bin:/home/travis/gopath/bin:/home/travis/.gimme/versions/go1.11.1.linux.amd64/bin:/usr/local/maven-3.6.0/bin:/usr/local/cmake-3.12.4/bin:/usr/local/clang-7.0.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/home/travis/.rvm/bin:/home/travis/.phpenv/bin:/opt/pyenv/bin:/home/travis/.yarn/bin
PYTHON_CFLAGS: -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security
PYTHON_CONFIGURE_OPTS: --enable-unicode=ucs4 --with-wide-unicode --enable-shared --enable-ipv6 --enable-loadable-sqlite-extensions --with-computed-gotos
REQUESTS_CA_BUNDLE: <not set>
SSL_CERT_FILE: <not set>
TRAVIS_APT_PROXY: <set>
rvm_bin_path: /home/travis/.rvm/bin
rvm_path: /home/travis/.rvm

travis_time:end:0a2ab180:start=1593451055316329338,finish=1593451055614189632,duration=297860294,event=before_install
[0Ktravis_fold:end:before_install.7
[0Ktravis_fold:start:install.1
[0Ktravis_time:start:2e3652da
[0K$ conda env create -q -f ci/requirements-$CONDA_ENV.yml
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... b' \nFor Linux 64, Open MPI is built with CUDA awareness but this support is disabled by default.\nTo enable it, please set the environmental variable OMPI_MCA_opal_cuda_support=true before\nlaunching your MPI processes. Equivalently, you can set the MCA parameter in the command line:\nmpiexec --mca opal_cuda_support 1 ...\n \n'
done
travis_time:end:2e3652da:start=1593451055618061071,finish=1593451123765627926,duration=68147566855,event=install
[0Ktravis_fold:end:install.1
[0Ktravis_fold:start:install.2
[0Ktravis_time:start:0e321b1c
[0K$ source activate test_env
travis_time:end:0e321b1c:start=1593451123769472185,finish=1593451123872231939,duration=102759754,event=install
[0Ktravis_fold:end:install.2
[0Ktravis_fold:start:install.3
[0Ktravis_time:start:215f3899
[0K$ pip install .
Processing /home/travis/build/ClimateImpactLab/open-estimate
Requirement already satisfied: numpy in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (1.18.5)
Requirement already satisfied: scipy in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (1.5.0)
Requirement already satisfied: emcee in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (0.0.0)
Requirement already satisfied: statsmodels in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (0.11.1)
Requirement already satisfied: xarray in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (0.15.1)
Requirement already satisfied: pandas in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (1.0.5)
Requirement already satisfied: metacsv in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from openest==3.0.0) (0.1.1)
Requirement already satisfied: patsy>=0.5 in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from statsmodels->openest==3.0.0) (0.5.1)
Requirement already satisfied: setuptools>=41.2 in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from xarray->openest==3.0.0) (47.3.1.post20200616)
Requirement already satisfied: pytz>=2017.2 in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from pandas->openest==3.0.0) (2020.1)
Requirement already satisfied: python-dateutil>=2.6.1 in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from pandas->openest==3.0.0) (2.8.1)
Requirement already satisfied: pyyaml>=3.0 in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from metacsv->openest==3.0.0) (5.3.1)
Requirement already satisfied: six in /home/travis/miniconda/envs/test_env/lib/python3.7/site-packages (from patsy>=0.5->statsmodels->openest==3.0.0) (1.15.0)
Building wheels for collected packages: openest
  Building wheel for openest (setup.py) ... [?25l- done
[?25h  Created wheel for openest: filename=openest-3.0.0-py3-none-any.whl size=167626 sha256=12b6611791c0602462eb68406fc401dfff9245d6d5b5ee345d3a6a64e909a6f4
  Stored in directory: /home/travis/.cache/pip/wheels/ef/b6/eb/de4efdacad38f56f475c8974b50e866f927bd1eb7d0290cf0c
Successfully built openest
Installing collected packages: openest
Successfully installed openest-3.0.0
travis_time:end:215f3899:start=1593451123876170800,finish=1593451125107641815,duration=1231471015,event=install
[0Ktravis_fold:end:install.3
[0Ktravis_time:start:0c4a5110
[0K$ pytest --pyargs openest
[1m============================= test session starts ==============================[0m
platform linux -- Python 3.7.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /home/travis/build/ClimateImpactLab/open-estimate
plugins: mock-3.1.1
[1mcollecting ... [0m[1m
collecting 4 items                                                             [0m[1m
collected 51 items                                                             [0m

test/generate/test_curvegen.py [32m.[0m[32m.[0m[33m                                        [  3%][0m
test/generate/test_daily.py [32m.[0m[32m.[0m[33m                                           [  7%][0m
test/generate/test_functions.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m          [ 68%][0m
test/lincombo/test_continuous_sampled.py [32m.[0m[33m                               [ 70%][0m
test/lincombo/test_hiernorm.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                     [ 80%][0m
test/lincombo/test_hierregress.py [32m.[0m[32m.[0m[32m.[0m[33m                                    [ 86%][0m
test/lincombo/test_multi_sampled.py Fatal Python error: Segmentation fault

Current thread 0x00007f1861d9c700 (most recent call first):
  File "<__array_function__ internals>", line 6 in dot
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/scipy/stats/_multivariate.py", line 474 in _logpdf
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/scipy/stats/_multivariate.py", line 526 in pdf
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/openest/test/lincombo/test_multi_sampled.py", line 12 in pdf
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/openest/lincombo/multi_sampled.py", line 115 in pdf
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/openest/lincombo/multi_sampled.py", line 94 in prepare_draws
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/openest/test/lincombo/test_multi_sampled.py", line 22 in test_multi_sampled
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/python.py", line 182 in pytest_pyfunc_call
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/python.py", line 1477 in runtest
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 135 in pytest_runtest_call
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 217 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 244 in from_call
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 217 in call_runtest_hook
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 186 in call_and_report
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 100 in runtestprotocol
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/runner.py", line 85 in pytest_runtest_protocol
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/main.py", line 272 in pytest_runtestloop
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/main.py", line 247 in _main
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/main.py", line 191 in wrap_session
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/home/travis/miniconda/envs/test_env/lib/python3.7/site-packages/_pytest/config/__init__.py", line 125 in main
  File "/home/travis/miniconda/envs/test_env/bin/pytest", line 11 in <module>
/home/travis/.travis/functions: line 109:  6430 Segmentation fault      (core dumped) pytest --pyargs openest
travis_time:end:0c4a5110:start=1593451125111533837,finish=1593451141001772833,duration=15890238996,event=script
[0K[31;1mThe command "pytest --pyargs openest" exited with 139.[0m


Done. Your build exited with 1.
```

Segmentation fault. Feels like a compiled resources problem.