### PR TITLE
Auxiliary* class corrections with legacy support

### DIFF
--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -907,6 +907,22 @@ class AuxiliaryResult(calculation.Calculation):
                     arguments=[arguments.calculation, arguments.calculation.describe("An auxiliary calculation, placed behind the main calculation."), arguments.label],
                     description="Add an additional result to the columns.")
 
+
+class AuxillaryResult(AuxiliaryResult):
+    """Deprecated variation of AuxiliaryResult
+
+    Emits a FutureWarning whenever used. Exists for backwards compatibility
+    and legacy support.
+    """
+    def init(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            "`AuxillaryResult` is deprecated, please use `AuxiliaryResult`",
+            FutureWarning
+        )
+        super().__init__(*args, **kwargs)
+
+
 class AuxiliaryResultApplication(calculation.Application):
     """
     Perform both main and auxiliary calculation, and order as main[0], aux, main[1:]

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -864,12 +864,12 @@ class Exponentiate(calculation.Calculation):
                     arguments=[arguments.calculation, arguments.variance.rename('errorvar')],
                     description="Return the the exponentiation of a previous result.")
 
-class AuxillaryResult(calculation.Calculation):
+class AuxiliaryResult(calculation.Calculation):
     """
     Produce an additional output, but then pass the main result on.
     """
     def __init__(self, subcalc_main, subcalc_aux, auxname):
-        super(AuxillaryResult, self).__init__([subcalc_main.unitses[0], subcalc_aux.unitses[0]] + subcalc_main.unitses[1:])
+        super(AuxiliaryResult, self).__init__([subcalc_main.unitses[0], subcalc_aux.unitses[0]] + subcalc_main.unitses[1:])
         self.subcalc_main = subcalc_main
         self.subcalc_aux = subcalc_aux
         self.auxname = auxname
@@ -891,7 +891,7 @@ class AuxillaryResult(calculation.Calculation):
         Returns a new calculation object that calculates the partial
         derivative with respect to a given variable; currently only covariates are supported.
         """
-        return AuxillaryResult(self.subcalc_main.partial_derivative(covariate, covarunit),
+        return AuxiliaryResult(self.subcalc_main.partial_derivative(covariate, covarunit),
                                self.subcalc_aux.partial_derivative(covariate, covarunit), self.auxname)
         
     def column_info(self):
@@ -904,7 +904,7 @@ class AuxillaryResult(calculation.Calculation):
     @staticmethod
     def describe():
         return dict(input_timerate='any', output_timerate='same',
-                    arguments=[arguments.calculation, arguments.calculation.describe("An auxillary calculation, placed behind the main calculation."), arguments.label],
+                    arguments=[arguments.calculation, arguments.calculation.describe("An auxiliary calculation, placed behind the main calculation."), arguments.label],
                     description="Add an additional result to the columns.")
 
 class AuxillaryResultApplication(calculation.Application):

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -884,7 +884,7 @@ class AuxiliaryResult(calculation.Calculation):
     def apply(self, region, *args, **kwargs):
         subapp_main = self.subcalc_main.apply(region, *args, **kwargs)
         subapp_aux = self.subcalc_aux.apply(region, *args, **kwargs)
-        return AuxillaryResultApplication(region, subapp_main, subapp_aux)
+        return AuxiliaryResultApplication(region, subapp_main, subapp_aux)
 
     def partial_derivative(self, covariate, covarunit):
         """
@@ -907,12 +907,12 @@ class AuxiliaryResult(calculation.Calculation):
                     arguments=[arguments.calculation, arguments.calculation.describe("An auxiliary calculation, placed behind the main calculation."), arguments.label],
                     description="Add an additional result to the columns.")
 
-class AuxillaryResultApplication(calculation.Application):
+class AuxiliaryResultApplication(calculation.Application):
     """
-    Perform both main and auxillary calculation, and order as main[0], aux, main[1:]
+    Perform both main and auxiliary calculation, and order as main[0], aux, main[1:]
     """
     def __init__(self, region, subapp_main, subapp_aux):
-        super(AuxillaryResultApplication, self).__init__(region)
+        super(AuxiliaryResultApplication, self).__init__(region)
         self.subapp_main = subapp_main
         self.subapp_aux = subapp_aux
 

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -942,6 +942,22 @@ class AuxiliaryResultApplication(calculation.Application):
         self.subapp_aux.done()
         return self.subapp_main.done()
 
+
+class AuxillaryResultApplication(AuxiliaryResultApplication):
+    """Deprecated variation of AuxiliaryResultApplication
+
+    Emits a FutureWarning whenever used. Exists for backwards compatibility
+    and legacy support.
+    """
+    def init(self, *args, **kwargs):
+        import warnings
+        warnings.warn(
+            "`AuxillaryResultApplication` is deprecated, please use `AuxiliaryResultApplication`",
+            FutureWarning
+        )
+        super().__init__(*args, **kwargs)
+
+
 class KeepOnly(calculation.Calculation):
     """
     Keep only a subset of the calculation results, with given names.


### PR DESCRIPTION
Corrects poor spelling of "auxillary" to "auxiliary" in `AuxillaryResult` and `AuxillaryResultApplication` within `openest/generate/functions.py`.

So, `AuxillaryResult` is refactored to `AuxiliaryResult` and `AuxillaryResultApplication` is refactored to `AuxiliaryResultApplication`.

This PR should maintain backwards compatibility: I subclassed the corrected `AuxiliaryResult` and `AuxiliaryResultApplication` to new child classes with the original misspelled name that emit a `FutureWarning` with a message about the correction whenever it is instantiated. This should allow us to support legacy for a time and keep folks' code from breaking.

Close #47 