### PR TITLE
setuptools_scm to handle package versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 from setuptools import setup, find_packages
 
 setup(name='openest',
-      version='3.0.0',
+      use_scm_version=True,
       description='Library of empirical model application.',
       url='http://github.com/jrising/open-estimate',
       author='James Rising',
       author_email='jarising@gmail.com',
       license='GNU v. 3',
       packages=find_packages(),
+      setup_requires=['setuptools_scm'],
       install_requires=['numpy', 'scipy', 'emcee', 'statsmodels', 'xarray',
                         'pandas', 'metacsv'],
       tests_require=['pytest', 'pytest-mock'],

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(name='openest',
       setup_requires=['setuptools_scm'],
       install_requires=['numpy', 'scipy', 'emcee', 'statsmodels', 'xarray',
                         'pandas', 'metacsv'],
-      tests_require=['pytest', 'pytest-mock'],
+      extras_require={
+            "test": ["pytest", "pytest-mock"],
+      },
       zip_safe=False,
       )


### PR DESCRIPTION
Very minor changes to package metadata.

This PR lets `setuptools_scm` handle package versioning so we don't need to set it manually. It sets the package version using the last version tag and using sensible "*.dev*" slugs for development versions between releases.

Should make it easier to see when researchers actually grab versions when they use development versions.

This PR also drops `test_requires` in setup.py, which can be a problem. Now uses a 'test' option to `extras_require`.

Close #49