### PR TITLE
Speed up numpy array sum

### DIFF
--- a/openest/generate/daily.py
+++ b/openest/generate/daily.py
@@ -239,7 +239,7 @@ class YearlyAverageDay(Calculation):
 
             temps2 = self.weather_change(region, temps)
             dailyresults = curve(temps2)
-            result = np.nansum(dailyresults) / sum(np.logical_not(np.isnan(dailyresults)))
+            result = np.nansum(dailyresults) / np.sum(np.logical_not(np.isnan(dailyresults)))
 
             if not self.norecord and diagnostic.is_recording():
                 if isinstance(temps2, xr.Dataset):


### PR DESCRIPTION
Profiling showed this might be an easy bottleneck to resolve.

Swapping `sum` with `np.sum` as `np.sum` is always faster on Numpy arrays.