### PR TITLE
Fix the stacking of variables in linear extrapolation

### DIFF
--- a/openest/curves/smart_linextrap.py
+++ b/openest/curves/smart_linextrap.py
@@ -58,7 +58,7 @@ class LinearExtrapolationCurve(SmartCurve):
             A sequence of values after clipping.
         """
         values = self.curve(ds)
-        indeps = np.stack((ds[indepvar] for indepvar in self.indepvars), axis=-1)
+        indeps = np.stack((ds[indepvar]._values for indepvar in self.indepvars), axis=-1)
 
         return linextrap.replace_oob(values, indeps, self.curve.univariate, self.bounds, self.margins, self.scaling)
 


### PR DESCRIPTION
Need to stack `numpy` arrays, not `Datasets`.