### PR TITLE
Support univariate curves for coefficient curves

### DIFF
--- a/openest/generate/smart_curve.py
+++ b/openest/generate/smart_curve.py
@@ -209,6 +209,7 @@ class SumByTimePolynomialCurve(SmartCurve):
                 
         return result
 
+    @property
     def univariate(self):
         raise NotImplementedError("Probably want to define a matrix-taking curve before this.")
 
@@ -299,6 +300,7 @@ class SumByTimeCoefficientsCurve(SmartCurve):
                 
         return result
 
+    @property
     def univariate(self):
         raise NotImplementedError("Probably want to define a matrix-taking curve before this.")
 

--- a/openest/generate/smart_curve.py
+++ b/openest/generate/smart_curve.py
@@ -355,7 +355,7 @@ class TransformCoefficientsCurve(SmartCurve):
         self.transforms = transforms
         self.descriptions = descriptions
         self.diagnames = diagnames
-        self.univariate_curve = univariate_curve
+        self._univariate_curve = univariate_curve
 
         assert isinstance(transforms, list) and len(transforms) == len(coeffs), "Transforms do not match coefficients: %s <> %s" % (transforms, coeffs)
         assert diagnames is None or isinstance(diagnames, list) and len(diagnames) == len(transforms)
@@ -388,8 +388,8 @@ class TransformCoefficientsCurve(SmartCurve):
 
     @property
     def univariate(self):
-        if self.univariate_curve is not None:
-            return self.univariate_curve
+        if self._univariate_curve is not None:
+            return self._univariate_curve
 
         raise NotImplementedError("univariate transform not specified")
 

--- a/openest/generate/smart_curve.py
+++ b/openest/generate/smart_curve.py
@@ -209,7 +209,7 @@ class SumByTimePolynomialCurve(SmartCurve):
                 
         return result
 
-    def get_univariate(self):
+    def univariate(self):
         raise NotImplementedError("Probably want to define a matrix-taking curve before this.")
 
     def format(self, lang):
@@ -299,7 +299,7 @@ class SumByTimeCoefficientsCurve(SmartCurve):
                 
         return result
 
-    def get_univariate(self):
+    def univariate(self):
         raise NotImplementedError("Probably want to define a matrix-taking curve before this.")
 
     def format(self, lang):
@@ -332,14 +332,28 @@ class CubicSplineCurve(CoefficientsCurve):
         return curve_module.CubicSplineCurve(self.knots, self.coeffs)
 
 class TransformCoefficientsCurve(SmartCurve):
-    """Use a transformation of ds to produce each predictor."""
-    
-    def __init__(self, coeffs, transforms, descriptions, diagnames=None):
+    """Use a transformation of ds to produce each predictor.
+
+    Parameters
+    ----------
+    coeffs : array_like
+        Vector of coefficients on each [transformed] predictor
+    transforms : list of functions
+        Functions of DataSet to return each predictor
+    descriptions : list of str
+        Descriptions of each transformation/predictor
+    diagnames : list of str (optional)
+        Keys to be used for each predictor in the diagnostic files, or None for no-recording
+    univariate_curve : UnivariateCurve (optional)
+        If a univariate function is requested, can we produce one?
+    """
+    def __init__(self, coeffs, transforms, descriptions, diagnames=None, univariate_curve=None):
         super(TransformCoefficientsCurve, self).__init__()
         self.coeffs = coeffs
         self.transforms = transforms
         self.descriptions = descriptions
         self.diagnames = diagnames
+        self.univariate_curve = univariate_curve
 
         assert isinstance(transforms, list) and len(transforms) == len(coeffs), "Transforms do not match coefficients: %s <> %s" % (transforms, coeffs)
         assert diagnames is None or isinstance(diagnames, list) and len(diagnames) == len(transforms)
@@ -369,7 +383,14 @@ class TransformCoefficientsCurve(SmartCurve):
             result[funcvars[ii]] = formatting.FormatElement(self.descriptions[ii])
 
         return result
-    
+
+    @property
+    def univariate(self):
+        if self.univariate_curve is not None:
+            return self.univariate_curve
+
+        raise NotImplementedError("univariate transform not specified")
+
 class SelectiveInputCurve(SmartCurve):
     """Assumes input is a matrix, and only pass selected input columns to child curve."""
     


### PR DESCRIPTION
Include an optional argument to `smart_curve.TransformCoefficientsCurve` to return a univariate curve, when requested.