### PR TITLE
Edits to support labor rebasing

### DIFF
--- a/openest/generate/calculation.py
+++ b/openest/generate/calculation.py
@@ -29,6 +29,7 @@ class Calculation(object):
         """Returns a dictionary of FormatElements.
         Only keys in the tree of dependencies will be output.
         """
+        print(self.__class__)
         raise NotImplementedError()
 
     def test(self):

--- a/openest/generate/calculation.py
+++ b/openest/generate/calculation.py
@@ -29,8 +29,7 @@ class Calculation(object):
         """Returns a dictionary of FormatElements.
         Only keys in the tree of dependencies will be output.
         """
-        print(self.__class__)
-        raise NotImplementedError()
+        raise NotImplementedError("%s does not implement .format" % self.__class__)
 
     def test(self):
         return self.apply('test')
@@ -59,8 +58,7 @@ class Calculation(object):
         Returns a new calculation object that calculates the partial
         derivative with respect to a given variable; currently only covariates are supported.
         """
-        print(self.__class__)
-        raise NotImplementedError()
+        raise NotImplementedError("%s does not implement .partial_derivative" % self.__class__)
 
     @staticmethod
     def describe():

--- a/openest/generate/formatting.py
+++ b/openest/generate/formatting.py
@@ -107,8 +107,10 @@ def format_julia(elements, parameters=None, include_comments=True):
         content = [main.repstr]
         
     for key, element in iter:
-        if element is None and key in map(lambda elt: elt.extname, functions_known.values()):
-            element = {elt.extname: elt for elt in functions_known.values()}[key]
+        if element is None and key in map(lambda elt: elt if isinstance(elt, str) else elt.extname, functions_known.values()):
+            element = {(elt if isinstance(elt, str) else elt.extname): elt for elt in functions_known.values()}[key]
+            if isinstance(element, str):
+                element = ParameterFormatElement(key, element)
         if element is None and key in parameters:
             element = ParameterFormatElement(key, get_parametername(key, 'julia'))
 
@@ -195,7 +197,7 @@ def get_variable(element=None):
 
     varvar = variables_vars[variables_count % len(variables_vars)]
     if variables_count / len(variables_vars) > 0:
-        varvar += str(variables_count / len(variables_vars) + 1)
+        varvar += str(int(variables_count / len(variables_vars)) + 1)
     variables_count += 1
     return varvar
 

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -201,10 +201,8 @@ class SpanInstabase(Instabase):
         baselinevar = formatting.get_parametername(self.baseline_diagname, lang)
         if lang == 'latex':
             result = latextools.call(func, "Re-basing function", eqvar, baselinevar)
-            #r"Average\left[%s\right]_{%d \le t le %d}" % (formatting.get_repstr(eqvar), self.year1, self.year2)
         elif lang == 'julia':
             result = juliatools.call(func, "Re-basing function", eqvar, baselinevar)
-            #"mean(%s[(year .>= %d) & (year .<= %d)])" % (formatting.get_repstr(eqvar), self.year1, self.year2)
         if isinstance(eqvar, str):
             result['main'].dependencies.append(eqvar)
             result[eqvar] = equation


### PR DESCRIPTION
This PR has two kinds of changes the come out of the debugging process for a labor configuration that includes rebasing of component calculations.
 - First, I needed to add more implementation (and changes to some existing implementations) of the `format` functions. These allow the calculations to be reported for debugging purposes.
 - Second, that led me to the default rebasing operation. Previously this was division (but that default is never used, since subtraction is used for normal rebasing). But it got used in the labor config. So I'm dropping the default, so one needs to specify it.