### PR TITLE
Add sequential process

### DIFF
--- a/openest/generate/curvegen.py
+++ b/openest/generate/curvegen.py
@@ -168,7 +168,7 @@ class DelayedCurveGenerator(CurveGenerator):
         self.curvegen = curvegen
         self.last_curves = {}
         self.last_years = {}
-        self.curve_cache = {}
+        self.current_curves = {}
         
     def get_curve(self, region, year, *args, **kwargs):
         """
@@ -189,7 +189,7 @@ class DelayedCurveGenerator(CurveGenerator):
         openest.generate.SmartCurve-like
         """
         if self.last_years.get(region, None) == year:
-            return self.curve_cache[region]
+            return self.current_curves[region]
         
         if region not in self.last_curves:
             # Calculate no-weather before update covariates by calling with weather
@@ -204,11 +204,8 @@ class DelayedCurveGenerator(CurveGenerator):
         self.last_years[region] = year
 
         # Save this curve in the cache
-        self.curve_cache[region] = curve
+        self.current_curves[region] = curve
         return curve
-
-    def get_most_recent_curve(self, region):
-        return self.curve_cache[region]
 
     def get_next_curve(self, region, year, *args, **kwargs):
         """

--- a/openest/generate/curvegen.py
+++ b/openest/generate/curvegen.py
@@ -35,7 +35,10 @@ class CurveGenerator(object):
         print(self.__class__)
         raise NotImplementedError()
 
+    def extrema_finder(self, mintemp, maxtemp, sign):
+        raise NotImplementedError()
 
+    
 class ConstantCurveGenerator(CurveGenerator):
     def __init__(self, indepunits, depenunit, curve):
         super(ConstantCurveGenerator, self).__init__(indepunits, depenunit)
@@ -156,6 +159,13 @@ class TransformCurveGenerator(CurveGenerator):
         else:
             raise NotImplementedError("Cannot produce partial derivative for transform %s" % self.description)
 
+    def extrema_finder(self, mintemp, maxtemp, sign):
+        # Default extrema_finder assumes transformation is not affected by transformation (very often the case)
+        if len(self.curvegens) > 1:
+            raise NotImplementedError()
+        return self.curvegens[0].extrema_finder(mintemp, maxtemp, sign)
+
+    
 class DelayedCurveGenerator(CurveGenerator):
     """
 
@@ -264,6 +274,10 @@ class DelayedCurveGenerator(CurveGenerator):
         """
         return DelayedCurveGenerator(self.curvegen.get_partial_derivative_curvegen(covariate, covarunit))
 
+    def extrema_finder(self, mintemp, maxtemp, sign):
+        return self.curvegen.extrema_finder(mintemp, maxtemp, sign)
+
+    
 class FunctionCurveGenerator(CurveGenerator):
     def __init__(self, indepunits, depenunits, covargen, curvegenfunc):
         super(FunctionCurveGenerator, self).__init__(indepunits, depenunits)

--- a/openest/generate/curvegen.py
+++ b/openest/generate/curvegen.py
@@ -6,7 +6,6 @@ from . import latextools
 
 from openest.models.curve import FlatCurve
 
-
 class CurveGenerator(object):
     """Abstract Base Class for curve generators
 
@@ -169,6 +168,7 @@ class DelayedCurveGenerator(CurveGenerator):
         self.curvegen = curvegen
         self.last_curves = {}
         self.last_years = {}
+        self.curve_cache = {}
         
     def get_curve(self, region, year, *args, **kwargs):
         """
@@ -189,7 +189,7 @@ class DelayedCurveGenerator(CurveGenerator):
         openest.generate.SmartCurve-like
         """
         if self.last_years.get(region, None) == year:
-            return self.last_curves[region]
+            return self.last_curves[region] # XXX: Should this self.curve_cache[region]?
         
         if region not in self.last_curves:
             # Calculate no-weather before update covariates by calling with weather
@@ -202,7 +202,13 @@ class DelayedCurveGenerator(CurveGenerator):
 
         self.last_curves[region] = self.get_next_curve(region, year, *args, **kwargs)
         self.last_years[region] = year
+
+        # Save this curve in the cache
+        self.curve_cache[region] = curve
         return curve
+
+    def get_most_recent_curve(self, region):
+        return self.curve_cache[region]
 
     def get_next_curve(self, region, year, *args, **kwargs):
         """

--- a/openest/generate/curvegen.py
+++ b/openest/generate/curvegen.py
@@ -189,7 +189,7 @@ class DelayedCurveGenerator(CurveGenerator):
         openest.generate.SmartCurve-like
         """
         if self.last_years.get(region, None) == year:
-            return self.last_curves[region] # XXX: Should this self.curve_cache[region]?
+            return self.curve_cache[region]
         
         if region not in self.last_curves:
             # Calculate no-weather before update covariates by calling with weather

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -1150,6 +1150,19 @@ class Reword(calculation.RecursiveCalculation):
                     description="Change the name and/or description of a result.")
 
 class SequentialProcess(calculation.RecursiveCalculation):
+    """
+    Perform two calculations in sequence, generally needed for the side-effects of the first one.
+
+    Attributes
+    ----------
+    step1: Calculation
+        The first calculation to perform.
+    step2: Calculation
+        The second calculation to perform.
+    reportstep1 : boolean
+        Should the outputs of step 1 be tacked on to the end of the results vector?
+    """
+
     def __init__(self, step1, step2, reportstep1=False):
         if reportstep1:
             super().__init__([step2, step1], step2.unitses + step1.unitses)

--- a/openest/generate/functions.py
+++ b/openest/generate/functions.py
@@ -1148,3 +1148,61 @@ class Reword(calculation.RecursiveCalculation):
                     arguments=[arguments.calculation, arguments.label.rename('name').optional(),
                                arguments.label.rename('title').optional(), arguments.description.optional()],
                     description="Change the name and/or description of a result.")
+
+class SequentialProcess(calculation.RecursiveCalculation):
+    def __init__(self, step1, step2, reportstep1=False):
+        if reportstep1:
+            super().__init__([step2, step1], step2.unitses + step1.unitses)
+        else:
+            super().__init__([step2, step1], step2.unitses)
+        self.step1 = step1
+        self.step2 = step2
+        self.reportstep1 = reportstep1
+
+    def format(self, lang, *args, **kwargs):
+        beforeauxlen = len(formatting.format_labels)
+        auxres = self.step1.format(lang, *args, **kwargs)
+        formatting.format_labels = formatting.format_labels[:beforeauxlen] # drop any new ones added
+        return self.step2.format(lang, *args, **kwargs)
+
+    def apply(self, region, *args, **kwargs):
+        app1 = self.step1.apply(region, *args, **kwargs)
+        app2 = self.step2.apply(region, *args, **kwargs)
+        return SequentialProcessApplication(region, app1, app2, self.reportstep1)
+
+    def partial_derivative(self, covariate, covarunit):
+        return SequentialProcess(self.step1.partial_derivative(covariate, covarunit),
+                                 self.step2.partial_derivative(covariate, covarunit))
+
+
+    def column_info(self):
+        if self.reportstep1:
+            return self.step2.column_info() + self.step1.column_info()
+        else:
+            return self.step2.column_info()
+
+    @staticmethod
+    def describe():
+        return dict(input_timerate='any', output_timerate='same',
+                    arguments=[arguments.calculation, arguments.calculation],
+                    description="Perform a first calculation, then return the result of a second.")
+
+class SequentialProcessApplication(calculation.Application):
+    def __init__(self, region, app1, app2, reportapp1):
+        super(SequentialProcessApplication, self).__init__(region)
+        self.app1 = app1
+        self.app2 = app2
+        self.reportapp1 = reportapp1
+        
+    def push(self, ds):
+        for yearresult1 in self.app1.push(ds):
+            for yearresult2 in self.app2.push(ds):
+                pass
+            if self.reportapp1:
+                yield list(yearresult2) + list(yearresult1[1:])
+            else:
+                yield yearresult2
+
+    def done(self):
+        self.app1.done()
+        return self.app2.done()

--- a/openest/test/generate/test_curvegen.py
+++ b/openest/test/generate/test_curvegen.py
@@ -45,7 +45,7 @@ def test_delayedcurvegenerator(mock_curvegen):
     assert dcg.last_years == {'a_region': 1984}
     assert dcg.last_curves == {'a_region': 'foobar'}
 
-    dcg.curve_cache['a_region'] = 'barfoo'
+    dcg.current_curves['a_region'] = 'barfoo'
     victim2 = dcg.get_curve(*args_in, **kwargs_in)
     assert victim2 == 'barfoo'
 

--- a/openest/test/generate/test_curvegen.py
+++ b/openest/test/generate/test_curvegen.py
@@ -45,7 +45,7 @@ def test_delayedcurvegenerator(mock_curvegen):
     assert dcg.last_years == {'a_region': 1984}
     assert dcg.last_curves == {'a_region': 'foobar'}
 
-    dcg.last_curves['a_region'] = 'barfoo'
+    dcg.curve_cache['a_region'] = 'barfoo'
     victim2 = dcg.get_curve(*args_in, **kwargs_in)
     assert victim2 == 'barfoo'
 

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -405,8 +405,8 @@ class TestSequentialProcess:
     """Tests for openest.generate.functions.SequentialProcess
     """
     def test_doublereport(self):
-        subcalc_step1 = MockAppCalc(years=[0], values=[1.0], unitses['none'])
-        subcalc_step2 = MockAppCalc(years=[0], values=[2.0], unitses['none'])
+        subcalc_step1 = MockAppCalc(years=[0], values=[1.0], unitses=['none'])
+        subcalc_step2 = MockAppCalc(years=[0], values=[2.0], unitses=['none'])
         seqcalc = SequentialProcess(subcalc_step1, subcalc_step2, reportstep1=True)
         for yearresult in seqcalc.apply('a region').push('not a ds'):
             np.testing.assert_equal(yearresult[1], 2.)

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -410,4 +410,4 @@ class TestSequentialProcess:
         seqcalc = SequentialProcess(subcalc_step1, subcalc_step2, reportstep1=True)
         for yearresult in seqcalc.apply('a region').push('not a ds'):
             np.testing.assert_equal(yearresult[1], 2.)
-            np.testing.assert_equal(yearresult[1], 1.)
+            np.testing.assert_equal(yearresult[2], 1.)

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -5,7 +5,7 @@ import pytest
 
 from openest.generate.base import Constant
 from openest.generate.daily import YearlyDayBins
-from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum, Product, FractionSum
+from openest.generate.functions import Scale, Instabase, SpanInstabase, Clip, Sum, Product, FractionSum, SequentialProcess
 from .test_daily import test_curve
 
 

--- a/openest/test/generate/test_functions.py
+++ b/openest/test/generate/test_functions.py
@@ -400,3 +400,14 @@ class TestClip:
         clipped_calc = Clip(subcalc_mock, 0.0, 1.0)
         victim = clipped_calc.describe()
         assert list(victim.keys()) == ['input_timerate', 'output_timerate', 'arguments', 'description']
+
+class TestSequentialProcess:
+    """Tests for openest.generate.functions.SequentialProcess
+    """
+    def test_doublereport(self):
+        subcalc_step1 = MockAppCalc(years=[0], values=[1.0], unitses['none'])
+        subcalc_step2 = MockAppCalc(years=[0], values=[2.0], unitses['none'])
+        seqcalc = SequentialProcess(subcalc_step1, subcalc_step2, reportstep1=True)
+        for yearresult in seqcalc.apply('a region').push('not a ds'):
+            np.testing.assert_equal(yearresult[1], 2.)
+            np.testing.assert_equal(yearresult[1], 1.)


### PR DESCRIPTION
This includes two changes needed to support the new labor clipping method (https://github.com/ClimateImpactLab/impact-calculations/pull/2).
 - `DelayedCurveGenerator` keeps track of the curve it most recently produced. This allows the clipping curve generator to get everything it needs from the dependent curve generator.
 - [Side-note: `DelayedCurveGenerator` actually always needed this, in case it was asked twice for a curve in a given year. The current implementation will give the next curve, for all requests after the first request.]
 - There's a new `SequentialProcess` function for calculations. This is now added implicitly by `create_calcstep` in `impact-calculations` in cases where a previous result is not used in a subsequent step.

Consider the following example:
```
calculation:
  - YearlyAverageDay:
      model: model1
  - YearlyAverageDay:
      model: model2
  - Rebase
```

Previously, only `model2` would ever be run, since its used by `Rebase`. But clearly the user intends for `model1` to be run (and presumably the results to be reported). So, upon reading the second `YearlyAverageDay` operation, both of these operations are wrapped in a `SequentialProcess`, and the resulting output (prior to the Rebase) is
```model2(T), model1(T)```.